### PR TITLE
Render-messages: usernames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ pom.xml.asc
 /resources/channels.edn
 /resources/users.edn
 /resources/logs
-
+.idea/
+clojurians-log.iml

--- a/src/clj/clojurians_log/components/parser.clj
+++ b/src/clj/clojurians_log/components/parser.clj
@@ -1,0 +1,23 @@
+(ns clojurians-log.components.parser
+  (:require [clojure.string :as str]))
+
+(defn- extract-texts
+  [messages]
+  (let [texts (map :message/text messages)]
+    (clojure.string/join " " texts)))
+
+(defn- parse-users
+  [texts]
+  (re-seq #"(?<=<@).*?(?=>)" texts))
+
+(defn extract-user-ids
+  "returns all the user/slack-ids from a string"
+  [messages]
+  (parse-users (extract-texts messages)))
+
+(defn replace-ids-names
+  "replaces user/slack-id with user/name"
+  [message id-names]
+  (str/replace message #"<@(.*?)>"
+               (fn [[whole-match partial-match]]
+                 (str "@" (get id-names partial-match)))))

--- a/src/clj/clojurians_log/db/queries.clj
+++ b/src/clj/clojurians_log/db/queries.clj
@@ -1,7 +1,6 @@
 (ns clojurians-log.db.queries
   (:require [datomic.api :as d]
-            [clojurians-log.time-util :as time-util]
-            [clojure.pprint :as pp]))
+            [clojurians-log.time-util :as time-util]))
 
 (defn channel-list
   ([db]

--- a/src/clj/clojurians_log/db/queries.clj
+++ b/src/clj/clojurians_log/db/queries.clj
@@ -58,10 +58,10 @@
 
 (defn user-names
   [db names]
-  (d/q '[:find ?ids ?username
-         :in $ [?ids ...]
+  (d/q '[:find ?id ?username
+         :in $ [?id ...]
          :where
-         [?user :user/slack-id ?ids]
+         [?user :user/slack-id ?id]
          [?user :user/name ?username]]
        db
        names))

--- a/src/clj/clojurians_log/db/queries.clj
+++ b/src/clj/clojurians_log/db/queries.clj
@@ -1,6 +1,7 @@
 (ns clojurians-log.db.queries
   (:require [datomic.api :as d]
-            [clojurians-log.time-util :as time-util]))
+            [clojurians-log.time-util :as time-util]
+            [clojure.pprint :as pp]))
 
 (defn channel-list
   ([db]
@@ -55,3 +56,13 @@
          [?chan :channel/name ?chan-name]]
        db
        name))
+
+(defn user-names
+  [db names]
+  (d/q '[:find ?ids ?username
+         :in $ [?ids ...]
+         :where
+         [?user :user/slack-id ?ids]
+         [?user :user/name ?username]]
+       db
+       names))

--- a/src/clj/clojurians_log/routes.clj
+++ b/src/clj/clojurians_log/routes.clj
@@ -4,7 +4,7 @@
             [clojurians-log.db.queries :as queries]
             [clojurians-log.response :as response]
             [clojurians-log.views :as views]
-            [clojurians-log.components.parser :as parser]
+            [clojurians-log.slack-messages :as slack-messages]
             [compojure.core :refer [GET routes]]
             [compojure.route :refer [resources]]
             [datomic.api :as d]
@@ -43,7 +43,7 @@
      (GET "/:channel/:date.html" [channel date :as request]
        (let [db (d/db conn)
              messages (queries/channel-day-messages db channel date)
-             user-ids (parser/extract-user-ids messages)]
+             user-ids (slack-messages/extract-user-ids messages)]
          (-> request
              context
              (assoc :data/channel (queries/channel db channel)

--- a/src/clj/clojurians_log/routes.clj
+++ b/src/clj/clojurians_log/routes.clj
@@ -8,8 +8,7 @@
             [compojure.core :refer [GET routes]]
             [compojure.route :refer [resources]]
             [datomic.api :as d]
-            [ring.util.response :refer [response]]
-            [clojure.pprint :as pp]))
+            [ring.util.response :refer [response]]))
 
 (defn context [request]
   {:request request})

--- a/src/clj/clojurians_log/slack_messages.clj
+++ b/src/clj/clojurians_log/slack_messages.clj
@@ -1,10 +1,10 @@
-(ns clojurians-log.components.parser
+(ns clojurians-log.slack-messages
   (:require [clojure.string :as str]))
 
 (defn- extract-texts
   [messages]
   (let [texts (map :message/text messages)]
-    (clojure.string/join " " texts)))
+    (str/join " " texts)))
 
 (defn- parse-users
   [texts]
@@ -13,7 +13,11 @@
 (defn extract-user-ids
   "returns all the user/slack-ids from a string"
   [messages]
-  (parse-users (extract-texts messages)))
+  (into #{} (comp
+              (map :message/text)
+              (map parse-users)
+              cat)
+        messages))
 
 (defn replace-ids-names
   "replaces user/slack-id with user/name"

--- a/src/clj/clojurians_log/views.clj
+++ b/src/clj/clojurians_log/views.clj
@@ -2,7 +2,8 @@
   (:require [hiccup2.core :as hiccup]
             [clojurians-log.time-util :as cl.tu]
             [clojure.string :as str]
-            [clojure.pprint :as pp]))
+            [clojure.pprint :as pp]
+            [clojurians-log.components.parser :as parser]))
 
 (defn page-head [{:data/keys [title channel date]}]
   [:head
@@ -25,7 +26,7 @@
   [:div.header
    [:div.team-menu [:a {:href "/"} "Clojurians"]]
    [:div.channel-menu
-    [:span.channel-menu_name [:span.channel-menu_prefix "#"] (:channel/name channel) ]]])
+    [:span.channel-menu_name [:span.channel-menu_prefix "#"] (:channel/name channel)]]])
 
 (defn- channel-list [{:data/keys [date channels]}]
   [:div.listings_channels
@@ -39,7 +40,7 @@
          {:href (str "/" name "/" date ".html")}
          [:span [:span.prefix "#"] " " name " (" message-count ")"]]]])]])
 
-(defn- message-history [{:data/keys [messages]}]
+(defn- message-history [{:data/keys [messages usernames]}]
   [:div.message-history
    (for [message messages
          :let [{:message/keys [user inst user text]} message
@@ -49,14 +50,13 @@
      ;; things in the profile
      ;; :image_512 :email :real_name_normalized :image_48 :image_192 :real_name :image_72 :image_24
      ;; :avatar_hash :title :team :image_32 :display_name :display_name_normalized
-
      [:div.message {:id (cl.tu/format-inst-id inst)}
       [:a.message_profile-pic {:href "" :style (str "background-image: url(" image-48 ");")}]
       [:a.message_username {:href ""} name]
       [:span.message_timestamp [:a {:href (str "#" (cl.tu/format-inst-id inst))} (cl.tu/format-inst-time inst)]]
       [:span.message_star]
       ;; TODO render slack style markdown (especially code blocks)
-      [:span.message_content [:p (hiccup/raw text)]]
+      [:span.message_content [:p (hiccup/raw (parser/replace-ids-names text usernames))]]
       #_[:pre {:style {:display "none"}} (with-out-str (pp/pprint message))]])])
 
 (defn- log-page-html [context]

--- a/src/clj/clojurians_log/views.clj
+++ b/src/clj/clojurians_log/views.clj
@@ -2,7 +2,6 @@
   (:require [hiccup2.core :as hiccup]
             [clojurians-log.time-util :as cl.tu]
             [clojure.string :as str]
-            [clojure.pprint :as pp]
             [clojurians-log.components.parser :as parser]))
 
 (defn page-head [{:data/keys [title channel date]}]

--- a/src/clj/clojurians_log/views.clj
+++ b/src/clj/clojurians_log/views.clj
@@ -2,7 +2,7 @@
   (:require [hiccup2.core :as hiccup]
             [clojurians-log.time-util :as cl.tu]
             [clojure.string :as str]
-            [clojurians-log.components.parser :as parser]))
+            [clojurians-log.slack-messages :as slack-messages]))
 
 (defn page-head [{:data/keys [title channel date]}]
   [:head
@@ -55,7 +55,7 @@
       [:span.message_timestamp [:a {:href (str "#" (cl.tu/format-inst-id inst))} (cl.tu/format-inst-time inst)]]
       [:span.message_star]
       ;; TODO render slack style markdown (especially code blocks)
-      [:span.message_content [:p (hiccup/raw (parser/replace-ids-names text usernames))]]
+      [:span.message_content [:p (hiccup/raw (slack-messages/replace-ids-names text usernames))]]
       #_[:pre {:style {:display "none"}} (with-out-str (pp/pprint message))]])])
 
 (defn- log-page-html [context]


### PR DESCRIPTION
This PR is for issue is for the first task of issue #1 
This was my approach:
1. join all messages for a given date
2. parse through all the messages and get the user-ids
3. query the db once to get the needed user-names 
3. replace the user-ids with user-names

I'm using two variations of somewhat similar regex because the different groupings make it easier to work in some situations : `(?<=<@).*?(?=>)` `<@(.*?)>`, but maybe I should stick to one.

Looking forward to your feedback. 
