### PR TITLE
Feature/day nav

### DIFF
--- a/resources/public/css/legacy.css
+++ b/resources/public/css/legacy.css
@@ -447,3 +447,14 @@ pre.highlight > code {
   border: none;
   color: inherit;
 }
+
+
+.day-arrows .day-prev {
+    display: inline-block;
+    margin-right: 0.3rem;
+}
+
+.day-arrows .day-next {
+    display: inline-block;
+    margin-left: 0.3rem;
+}

--- a/resources/public/css/legacy.css
+++ b/resources/public/css/legacy.css
@@ -448,13 +448,28 @@ pre.highlight > code {
   color: inherit;
 }
 
+.day-arrows {
+  margin-left: 1rem;
+}
 
 .day-arrows .day-prev {
     display: inline-block;
     margin-right: 0.3rem;
+    background-color: rgb(62, 49, 60);
+    color: white;
+    min-height: 1rem;
+    min-width: 1rem;
+    text-align: center;
+    border-radius: 20%;
 }
 
 .day-arrows .day-next {
     display: inline-block;
     margin-left: 0.3rem;
+    background-color: rgb(62, 49, 60);
+    color: white;
+    min-height: 1rem;
+    min-width: 1rem;
+    text-align: center;
+    border-radius: 20%;
 }

--- a/resources/public/css/legacy.css
+++ b/resources/public/css/legacy.css
@@ -447,29 +447,3 @@ pre.highlight > code {
   border: none;
   color: inherit;
 }
-
-.day-arrows {
-  margin-left: 1rem;
-}
-
-.day-arrows .day-prev {
-    display: inline-block;
-    margin-right: 0.3rem;
-    background-color: rgb(62, 49, 60);
-    color: white;
-    min-height: 1rem;
-    min-width: 1rem;
-    text-align: center;
-    border-radius: 20%;
-}
-
-.day-arrows .day-next {
-    display: inline-block;
-    margin-left: 0.3rem;
-    background-color: rgb(62, 49, 60);
-    color: white;
-    min-height: 1rem;
-    min-width: 1rem;
-    text-align: center;
-    border-radius: 20%;
-}

--- a/src/clj/clojurians_log/routes.clj
+++ b/src/clj/clojurians_log/routes.clj
@@ -46,6 +46,7 @@
              (assoc :data/channel (queries/channel db channel)
                     :data/channels (queries/channel-list db date)
                     :data/messages (queries/channel-day-messages db channel date)
+                    :data/channel-days (queries/channel-days db channel)
                     :data/title (str channel " " date " | Clojurians Slack Log")
                     :data/date date)
              views/log-page

--- a/src/clj/clojurians_log/styles.clj
+++ b/src/clj/clojurians_log/styles.clj
@@ -1,5 +1,25 @@
 (ns clojurians-log.styles
-  (:require [garden-watcher.def :refer [defstyles]]))
+  (:require [garden-watcher.def :refer [defstyles]]
+            [garden.color :as c]))
+
+(def primary-color (c/rgb 62 49 60))
+
+(def small-square-button
+  {:display :inline-block
+   :background-color primary-color
+   :color :white
+   :min-height "1rem"
+   :min-width "1rem"
+   :text-align :center
+   :border-radius "20%"})
 
 (defstyles style
-  [:h1 {:text-decoration "underline"}])
+  [:h1 {:text-decoration "underline"}]
+
+  [:.day-arrows
+   {:margin-left "1rem"}
+
+   [:div.day-prev (assoc small-square-button
+                         :margin-right "0.3rem")]
+   [:div.day-next (assoc small-square-button
+                         :margin-left "0.3rem")]])

--- a/src/clj/clojurians_log/views.clj
+++ b/src/clj/clojurians_log/views.clj
@@ -21,11 +21,32 @@
    ;; styling over in clean Garden or Garden+Tachyons.
    [:link {:href "/css/legacy.css", :rel "stylesheet", :type "text/css"}]])
 
-(defn- log-page-header [{:data/keys [channel]}]
+(defn channel-day-offset
+  "Given a list of [date msg-count] pairs, return `date` of the entry that is
+  `offset` positions away. Returns nil if the applying the offset goes out of
+  bounds."
+  [channel-days today offset]
+
+  (as-> channel-days $
+    (some (fn [[index [a-date msg-count]]] (when (and (= a-date today)
+                                                     (not (zero? msg-count)))
+                                            index))
+          (map vector (range) $))
+    (+ $ offset)
+    (nth channel-days $ nil)
+    (first $)))
+
+(defn- log-page-header [{:data/keys [channel date channel-days]}]
   [:div.header
    [:div.team-menu [:a {:href "/"} "Clojurians"]]
    [:div.channel-menu
-    [:span.channel-menu_name [:span.channel-menu_prefix "#"] (:channel/name channel) ]]])
+    [:span.channel-menu_name [:span.channel-menu_prefix "#"] (:channel/name channel) ]
+    [:span.day-arrows
+     (if-let [prev-date (channel-day-offset channel-days date -1)]
+       [:a {:href (str prev-date ".html")} [:div.day-prev "<"]])
+     date
+     (if-let [next-date (channel-day-offset channel-days date 1)]
+       [:a {:href (str next-date ".html")} [:div.day-next ">"]])]]])
 
 (defn- channel-list [{:data/keys [date channels]}]
   [:div.listings_channels

--- a/src/clj/clojurians_log/views.clj
+++ b/src/clj/clojurians_log/views.clj
@@ -29,10 +29,10 @@
   [channel-days today offset]
 
   (as-> channel-days $
+    (map vector (range) $)
     (some (fn [[index [a-date msg-count]]] (when (and (= a-date today)
                                                      (not (zero? msg-count)))
-                                            index))
-          (map vector (range) $))
+                                            index)) $)
     (+ $ offset)
     (nth channel-days $ nil)
     (first $)))

--- a/src/clj/clojurians_log/views.clj
+++ b/src/clj/clojurians_log/views.clj
@@ -19,7 +19,8 @@
    ;; This one is just copied over from the static site, seems it was generated
    ;; with Compass and SASS. At some point I'd prefer to delete this and do the
    ;; styling over in clean Garden or Garden+Tachyons.
-   [:link {:href "/css/legacy.css", :rel "stylesheet", :type "text/css"}]])
+   [:link {:href "/css/legacy.css", :rel "stylesheet", :type "text/css"}]
+   [:link {:href "/css/style.css", :rel "stylesheet", :type "text/css"}]])
 
 (defn channel-day-offset
   "Given a list of [date msg-count] pairs, return `date` of the entry that is


### PR DESCRIPTION
Howdy!

This PR implements the feature outlined in #4.

It adds next/prev links to the header of the message page. The links will only show up when it's possible to navigate in said direction and will/should also skip days without messages.

Note that I left the function `channel-day-offset` in clojurians_log/views.clj. That's probably not the right place to leave that function, but I didn't see an obvious place where the function can live.

Closes #4.