### PR TITLE
Adds cache-control directive to message page response

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -69,3 +69,7 @@
    :coordinates [dep-vec]
    :repositories (merge @(resolve 'cemerick.pomegranate.aether/maven-central)
                         {"clojars" "https://clojars.org/repo"})))
+
+(defn update-cache-time! [new-cache-time]
+  "Changes how long to ask http clients to cache each of the messages pages"
+  (alter-var-root #'app/config update-in [:message-page :cache-time] (constantly new-cache-time)))

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,6 +1,7 @@
 (ns user
   (:require [clojurians-log.application :as app]
             [clojurians-log.config :as config :refer [config]]
+            [clojurians-log.repl :as repl]
             [figwheel-sidecar.config :as fw-config]
             [figwheel-sidecar.system :as fw-sys]
             [garden-watcher.core :refer [new-garden-watcher]]
@@ -9,6 +10,7 @@
             [reloaded.repl :refer [system]]
             [ring.middleware.cookies :as cookies]
             [ring.middleware.session.store :as session-store]
+            [system.components.middleware :refer [new-middleware]]
             [datomic.api :as d]))
 
 (defn dev-system []
@@ -16,7 +18,8 @@
     (alter-var-root #'app/config (constantly config))
     (-> (app/prod-system config)
         (ring-history/inject-ring-history)
-        (assoc :figwheel-system (fw-sys/figwheel-system (fw-config/fetch-config))
+        (assoc :middleware (new-middleware {:middleware (clojurians-log.config/middleware-stack :dev)})
+               :figwheel-system (fw-sys/figwheel-system (fw-config/fetch-config))
                :css-watcher (fw-sys/css-watcher {:watch-paths ["resources/public/css"]})
                :garden-watcher (new-garden-watcher ['clojurians-log.styles])
                #_#_:browse-url (browse-url/new-browse-url-component (str "http://localhost:" (get-in config [:http :port])))))))
@@ -72,4 +75,5 @@
 
 (defn update-cache-time! [new-cache-time]
   "Changes how long to ask http clients to cache each of the messages pages"
-  (alter-var-root #'app/config update-in [:message-page :cache-time] (constantly new-cache-time)))
+  (swap! (get-in system [:config :value]) update-in [:message-page :cache-time] (constantly new-cache-time))
+  true)

--- a/resources/clojurians-log/config.edn
+++ b/resources/clojurians-log/config.edn
@@ -1,4 +1,6 @@
 {:datomic {:uri #or [#env DATOMIC_URI "datomic:mem:clojurians_log"]}
  :http {:port #long #or [#env CLOJURIANS_LOG_PORT 4983]}
  :slack {:api-token #env SLACK_API_TOKEN
-         :log-dir #env CLOJURIANS_LOG_DIR}}
+         :log-dir #env CLOJURIANS_LOG_DIR}
+ :message-page {:cache-time #profile {:default (* 24 60 60)
+                                      :dev 0}}}

--- a/src/clj/clojurians_log/config.clj
+++ b/src/clj/clojurians_log/config.clj
@@ -42,8 +42,6 @@
 
 (defn config
   ([file profile]
-   (assoc-in (aero/read-config file {:profile profile})
-             [:http :middleware]
-             (middleware-stack profile)))
+   (aero/read-config file {:profile profile}))
   ([profile]
    (config (io/resource "clojurians-log/config.edn") profile)))

--- a/src/clj/clojurians_log/routes.clj
+++ b/src/clj/clojurians_log/routes.clj
@@ -26,7 +26,7 @@
       (println (.isEqual fetch-date page-date))
       (.isEqual fetch-date page-date))))
 
-(defn home-routes [endpoint]
+(defn home-routes [{:keys [config] :as endpoint}]
   (let [conn (get-in endpoint [:datomic :conn])]
     (routes
      (GET "/healthcheck" _
@@ -54,8 +54,7 @@
 
      ;; https://clojurians-log.clojureverse.org/clojure/2017-11-15.html
      (GET "/:channel/:date.html" [channel date :as request]
-       (let [config (var-get (resolve 'clojurians-log.application/config))
-             cache-time (get-in config [:message-page :cache-time])]
+       (let [cache-time (get-in @(:value config) [:message-page :cache-time] 0)]
 
          ;; Since we're displaying a log, presumably, all of the content is permanently cachable
          ;; Message page content also most likely have not changed and does not require any processing/page-generation.

--- a/src/clj/clojurians_log/routes.clj
+++ b/src/clj/clojurians_log/routes.clj
@@ -5,6 +5,8 @@
             [clojurians-log.response :as response]
             [clojurians-log.views :as views]
             [clojurians-log.slack-messages :as slack-messages]
+            [clojurians-log.time-util :as time-util]
+            [java-time :as jt]
             [compojure.core :refer [GET routes]]
             [compojure.route :refer [resources]]
             [datomic.api :as d]
@@ -12,6 +14,17 @@
 
 (defn context [request]
   {:request request})
+
+(defn message-page-might-have-updated?
+  [page-date-str last-fetch-time-ts]
+
+  (if (nil? last-fetch-time-ts)
+    true
+
+    (let [fetch-date (jt/local-date (jt/zoned-date-time (time-util/html-ts->time last-fetch-time-ts)))
+          page-date (jt/local-date time-util/inst-day-formatter page-date-str)]
+      (println (.isEqual fetch-date page-date))
+      (.isEqual fetch-date page-date))))
 
 (defn home-routes [endpoint]
   (let [conn (get-in endpoint [:datomic :conn])]
@@ -41,20 +54,34 @@
 
      ;; https://clojurians-log.clojureverse.org/clojure/2017-11-15.html
      (GET "/:channel/:date.html" [channel date :as request]
-       (let [db (d/db conn)
-             messages (queries/channel-day-messages db channel date)
-             user-ids (slack-messages/extract-user-ids messages)]
-         (-> request
-             context
-             (assoc :data/channel (queries/channel db channel)
-                    :data/channels (queries/channel-list db date)
-                    :data/messages messages
-                    :data/usernames (into {} (queries/user-names db user-ids))
-                    :data/channel-days (queries/channel-days db channel)
-                    :data/title (str channel " " date " | Clojurians Slack Log")
-                    :data/date date)
-             views/log-page
-             response/render)))
+       (let [config (var-get (resolve 'clojurians-log.application/config))
+             cache-time (get-in config [:message-page :cache-time])]
+
+         ;; Since we're displaying a log, presumably, all of the content is permanently cachable
+         ;; Message page content also most likely have not changed and does not require any processing/page-generation.
+         ;; In those cases, skip page generate entirely, instead of generating the contents, then have the ring
+         ;; middleware respond with a 304.
+         (if (and (not (zero? cache-time))
+                  (not (message-page-might-have-updated? date (get-in request [:headers "if-modified-since"]))))
+           (-> (ring.util.response/response nil)
+               (ring.util.response/status 304))
+
+           (let [db (d/db conn)
+                 messages (queries/channel-day-messages db channel date)
+                 user-ids (slack-messages/extract-user-ids messages)]
+             (-> request
+                 context
+                 (assoc :data/channel (queries/channel db channel)
+                        :data/channels (queries/channel-list db date)
+                        :data/messages messages
+                        :data/usernames (into {} (queries/user-names db user-ids))
+                        :data/channel-days (queries/channel-days db channel)
+                        :data/title (str channel " " date " | Clojurians Slack Log")
+                        :data/date date)
+                 views/log-page
+                 (assoc-in [:response/headers "Cache-Control"] (str "public, max-age: " cache-time))
+                 (assoc-in [:response/headers "Last-Modified"] (time-util/time->html-ts (jt/zoned-date-time time-util/UTC)))
+                 response/render)))))
 
      (resources "/"))))
 

--- a/src/clj/clojurians_log/time_util.clj
+++ b/src/clj/clojurians_log/time_util.clj
@@ -1,7 +1,8 @@
 (ns clojurians-log.time-util
   (:require [java-time :as jt]
             [clojure.string :as str])
-  (:import [java.time Instant]))
+  (:import [java.time Instant]
+           [java.time.format DateTimeFormatter]))
 
 (defn ts->inst
   "Convert a Slack timestamp like \"1433399521.000490\" into a java.time.Instant like
@@ -36,3 +37,11 @@
   "Format an instant as year-month-day, e.g. 2017-11-20."
   [inst]
   (jt/format inst-day-formatter inst))
+
+(defn time->html-ts
+  [zoned-dt]
+  (jt/format DateTimeFormatter/RFC_1123_DATE_TIME zoned-dt))
+
+(defn html-ts->time
+  [ts]
+  (jt/zoned-date-time DateTimeFormatter/RFC_1123_DATE_TIME ts))


### PR DESCRIPTION
Howdy!

This is a first attempt at implementing #7.

---
The commit adds the following functionality:
- Message page response marked publicly cachable
  Browsers can proxies should see this directive and cache the page contents
  locally. Default cache time in production is currently 1 day and can be
  altered via config.edn.

- Message page content not regenerated if it's unlikely the content has changed
  The response is also marked with the "Last-Modified" directive. This is simply
  a timestamp of when the client last fetched the content.

  Since log page contents do not usually change, we should be able to answer
  with a 304 (Not Modified) most of the time. The only time when this might not
  be true should be when the client was viewing the message log for the current
  day, where the content can change as the day goes on.

- Caching directives are disabled (set to 0) when in development mode
  This is also set via config.edn.

---
### Trying the patch
To properly see the cache-control and 304 responses in action, update config.edn's [:message-page :cache-time :dev] to a non-zero value. You should see the app attach the cache-control directive to the output, as well as responding with a 304 when reloading the page.