### PR TITLE
Slack message parser

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,8 @@
                  [lambdaisland/repl-tools "0.1.0"]
                  [clj-http "3.7.0"]
                  [org.julienxx/clj-slack "0.5.5"]
-                 [reloaded.repl "0.2.4"]]
+                 [reloaded.repl "0.2.4"]
+                 [instaparse "1.4.8"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-environ "1.1.0"]]

--- a/resources/clojurians-log/slack-message.bnf
+++ b/resources/clojurians-log/slack-message.bnf
@@ -1,0 +1,21 @@
+<slack-message> = ( code / reference / emoji / styled / undecorated )*
+
+<code> = code-block / inline-code
+code-block = <code-block-delimiter> #"(?s).*(?=```)" <code-block-delimiter>
+code-block-delimiter = "```"
+
+<reference> = <"<@"> slack-id <">">
+<slack-id> = user-id | channel-id
+user-id = #"U[A-Z0-9]{7,}"
+channel-id = #"C[A-Z0-9]{7,}"
+
+inline-code = <"`"> #"[^`]+" <"`">
+emoji = <":"> #"[^:]+" <":">
+
+<styled> = strong | bold
+strong = <"_"> #"[^_]+" <"_">
+bold = <"*"> #"[^\*]+" <"*">
+
+undecorated = notwhitespace | whitespace
+<notwhitespace> = #"\S+"
+<whitespace> = #"\s+"

--- a/src/clj/clojurians_log/message.clj
+++ b/src/clj/clojurians_log/message.clj
@@ -1,0 +1,29 @@
+(ns clojurians-log.message
+  (:require [instaparse.core :as insta]
+            [clojure.java.io :as io]))
+
+(def parser
+  (insta/parser
+   (io/resource "clojurians-log/slack-message.bnf")))
+
+(defn join-adjacent
+  "Takes output from an insta-parse parser and returns a new
+  vector of tokens with repeated types merged.
+  eg. (join-adjacent [[:undecorated \"Hello\"] [:undecorated \" \"] [:undecorated \"World\"]])
+  yields: [[:undecorated \"Hello World\"]]"
+  [tokens]
+  (reduce (fn [result [type content :as token]]
+            (let [[prev-type prev-content :as prev-token] (last result)]
+              (if (and type
+                       (= :undecorated prev-type)
+                       (= :undecorated type))
+                (assoc result (dec (count result)) [:undecorated (str prev-content content)])
+                (conj result token))))
+          [] tokens))
+
+(defn parse
+  "Returns a vector of [type string] pairs, where type identifies one of the special markup types available in slack.
+  eg. (parse \"Hello *bold*!\")
+  yields: [[:undecorated \"Hello \"] [:bold \"bold\"] [:undecorated \"!\"]]"
+  [message]
+  (join-adjacent (parser message)))

--- a/test/clj/clojurians_log/message_test.clj
+++ b/test/clj/clojurians_log/message_test.clj
@@ -1,0 +1,49 @@
+(ns clojurians-log.message-test
+  (:require [clojurians-log.message :refer [parse] :as sut]
+            [clojure.test :refer :all]))
+
+(deftest test-parse
+  (testing "basic messages"
+    (is (= [[:undecorated "This is a normal message"]]
+           (parse "This is a normal message")))
+    (is (= [[:user-id "U4F2A0Z8ER"]]
+           (parse "<@U4F2A0Z8ER>")))
+    (is (= [[:channel-id "C4F2A26SGSHBW"]]
+           (parse "<@C4F2A26SGSHBW>")))
+    (is (= [[:inline-code "DateTime"]]
+           (parse "`DateTime`")))
+    (is (= [[:code-block "(some clojure code)"]]
+           (parse "```(some clojure code)```")))
+    (is (= [[:bold "hey!"]]
+           (parse "*hey!*")))
+    (is (= [[:strong "hello"]]
+           (parse "_hello_")))
+    (is (= [[:emoji "thumbsup"]]
+           (parse ":thumbsup:")))
+    (is (= [[:undecorated "just_some_snake_case"]]
+           (parse "just_some_snake_case"))))
+
+  (testing "putting it together"
+    (let [message "Hey <@U4F2A0Z8ER> here is the `my-ns.core` code ```
+  (let [code 42]
+   (inc code))
+```
+*what do* _you_ *think* :mindblown:
+please respond in <@C346HE24SD>"]
+      (is (= [[:undecorated "Hey "]
+              [:user-id "U4F2A0Z8ER"]
+              [:undecorated " here is the "]
+              [:inline-code "my-ns.core"]
+              [:undecorated " code "]
+              [:code-block "\n  (let [code 42]\n   (inc code))\n"]
+              [:undecorated "\n"]
+              [:bold "what do"]
+              [:undecorated " "]
+              [:strong "you"]
+              [:undecorated " "]
+              [:bold "think"]
+              [:undecorated " "]
+              [:emoji "mindblown"]
+              [:undecorated "\nplease respond in "]
+              [:channel-id "C346HE24SD"]]
+             (parse message))))))


### PR DESCRIPTION
Message parts currently parsed:
* user id
* channel id
* inline code
* code blocks
* bold
* strong
* emoji
* "un-decorated" - everything that doesn't fall into one of the other categories

There may be other formatting I have missed. I will certainly verify this before
merging.