### PR TITLE
Fixes broken day nav when viewing a specific log message

### DIFF
--- a/src/clj/clojurians_log/views.clj
+++ b/src/clj/clojurians_log/views.clj
@@ -44,10 +44,10 @@
     [:span.channel-menu_name [:span.channel-menu_prefix "#"] (:channel/name channel)]
     [:span.day-arrows
      (if-let [prev-date (channel-day-offset channel-days date -1)]
-       [:a {:href (str prev-date ".html")} [:div.day-prev "<"]])
+       [:a {:href (str "/" (:channel/name channel) "/" prev-date ".html")} [:div.day-prev "<"]])
      date
      (if-let [next-date (channel-day-offset channel-days date 1)]
-       [:a {:href (str next-date ".html")} [:div.day-next ">"]])]]])
+       [:a {:href (str "/" (:channel/name channel) "/" next-date ".html")} [:div.day-next ">"]])]]])
 
 (defn- channel-list [{:data/keys [date channels]}]
   [:div.listings_channels


### PR DESCRIPTION
It appears that the day nav buttons are broken when the user is viewing a specific log message using the /:channel/:day/:ts route.

This fixes the bug.

---
- [x] My code conforms to this project's [Style Guide](https://github.com/clojureverse/clojurians-log-app/blob/master/docs/STYLE.md)
- [x] I have added tests for functions or features I've added
- [x] All tests are green (`lein test`)
