### PR TITLE
Emoji do not include white space.

### DIFF
--- a/resources/clojurians-log/slack-message.bnf
+++ b/resources/clojurians-log/slack-message.bnf
@@ -10,7 +10,7 @@ inline-code = <"`"> #"[^`]+" <"`">
 user-id = #"U[A-Z0-9]{7,}"
 channel-id = #"C[A-Z0-9]{7,}"
 
-emoji = <":"> #"[^:]+" <":">
+emoji = <":"> #"[^:\s]+" <":">
 
 <styled> = italic | bold
 italic = <"_"> #"[^_]+" <"_">

--- a/test/clj/clojurians_log/message_parser_test.clj
+++ b/test/clj/clojurians_log/message_parser_test.clj
@@ -24,7 +24,7 @@
            (parse "just_some_snake_case"))))
 
   (testing "putting it together"
-    (let [message "Hey <@U4F2A0Z8ER> here is the `my-ns.core` code ```
+    (let [message "Hey <@U4F2A0Z8ER>: here is the `my-ns.core` code ```
   (let [code 42]
    (inc code))
 ```
@@ -32,7 +32,7 @@
 please respond in <@C346HE24SD>"]
       (is (= [[:undecorated "Hey "]
               [:user-id "U4F2A0Z8ER"]
-              [:undecorated " here is the "]
+              [:undecorated ": here is the "]
               [:inline-code "my-ns.core"]
               [:undecorated " code "]
               [:code-block "(let [code 42]\n   (inc code))\n"]


### PR DESCRIPTION
Fix a bug with message parsing which was causing overly-eager emoji identification

- [x] My code conforms to this project's [Style Guide](https://github.com/clojureverse/clojurians-log-app/blob/master/docs/STYLE.md)
- [x] I have added tests for functions or features I've added
- [x] All tests are green (`lein test`)
