### PR TITLE
[WIP] Initial attempt at faster slack message parser

### DIFF
--- a/src/clj/clojurians_log/message_parser.clj
+++ b/src/clj/clojurians_log/message_parser.clj
@@ -1,6 +1,7 @@
 (ns clojurians-log.message-parser
   (:require [instaparse.core :as insta]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
 
 (def parser
   (insta/parser
@@ -27,3 +28,121 @@
   yields: [[:undecorated \"Hello \"] [:bold \"bold\"] [:undecorated \"!\"]]"
   [message]
   (join-adjacent (parser message)))
+
+(defn re-seq-pos [pattern string]
+  (let [m (re-matcher pattern string)]
+    ((fn step []
+       (when (.find m)
+         (cons (cond-> {:start (.start m) :end (.end m) :match (.group m)}
+                 (> (.groupCount m) 0)
+                 (assoc :matches
+                        (re-groups m)))
+               (lazy-seq (step))))))))
+
+(def message-patterns
+  {:code-block #"```(?s:(.*?))```"
+   :inline-code #"`(.*?)`"
+   :reference #"<((?:#C|@U)[A-Z0-9]{7,})(?:\|(.*?))?>"
+   :emoji #":(.*?):"
+   :italic #"\b_(.*?)_"
+   :bold #"\*(.*?)\*"
+   :strike-through #"\b~(.*?)~"})
+
+(defn match-all-patterns [message-patterns message]
+  (apply concat
+         (for [[pattern-k pattern] message-patterns]
+           (if-let [result (re-seq-pos pattern message)]
+             (map #(assoc % :type pattern-k) result)))))
+
+(defn- match-compare [m1 m2]
+  ;; Order matches such that...
+  (cond
+    ;; Items with smallest start fields sorts to the top.
+    (not= (:start m1) (:start m2))
+    (- (:start m1) (:start m2))
+
+    ;; If two blocks/patterns start at the same location then the larger
+    ;; block/pattern takes precedence and sorts to the top.
+    (not= (:end m1) (:end m2))
+    (- (:end m2) (:end m1))
+
+    ;; We shouldn't really reach here.
+    :else
+    (assert false "missing match comparison case")))
+
+(defn- match->token [match]
+  (condp = (:type match)
+    :reference
+    (let [[_ ref name] (:matches match)
+          ref-type (condp = (second ref)
+                       \U :user-id
+                       \C :channel-id)]
+      (cond-> [ref-type (subs ref 1)]
+        (not (empty? name))
+        (conj name)))
+
+    :code-block
+    [(:type match) (str/triml (nth (:matches match) 1))]
+
+    [(:type match) (or (nth (:matches match) 1)
+                       (:match match))]))
+
+(defn parse2 [message]
+  (let [matches (->> (match-all-patterns message-patterns message)
+                     (sort match-compare))]
+
+    ;; (clojure.pprint/pprint matches)
+    ;; Loop starting from the beginning of the message string...
+    (loop [cursor 0
+           matches matches
+           result []]
+
+      (cond
+        ;; If there are no more characters in the message to process, we're done.
+        ;; Return the results accumulated so far
+        (>= cursor (count message))
+        result
+
+        ;; There are still characters to be processed...
+        ;; If there are no more matches in the rest of the message,
+        ;; mark the rest of the message as undecorated.
+        (empty? matches)
+        (conj result [:undecorated (subs message cursor)])
+
+        ;; If the starting location of the match is less than the current cursor,
+        ;; this means we already came across a better/larger match previously.
+        ;; We should move on to the next match and discard this one.
+        (> cursor (:start (first matches)))
+        (recur cursor (rest matches) result)
+
+        :else
+        (let [match (first matches)]
+          (recur (:end match)
+                 (rest matches)
+                 (cond-> result
+                   (> (:start match) cursor)
+                   (conj [:undecorated (subs message cursor (:start match))])
+                   :finally
+                   (conj (match->token match)))))))))
+
+(defn parse-pattern
+  [pattern-k message]
+
+  (let [pattern (get message-patterns pattern-k)]
+    (re-seq-pos pattern message)))
+
+(comment
+
+  (let [data (clojurians-log.db.queries/channel-day-messages (user/db) "clojure" "2018-02-02")]
+    (time (->> data
+               (map #(parse (:message/text %)))
+               doall))
+    nil)
+
+  (let [data (clojurians-log.db.queries/channel-day-messages (user/db) "clojure" "2018-02-02")]
+    (time (->> data
+               (map #(parse2 (:message/text %)))
+               doall))
+    nil)
+
+)

--- a/src/clj/clojurians_log/slack_messages.clj
+++ b/src/clj/clojurians_log/slack_messages.clj
@@ -68,7 +68,7 @@
   [message usernames]
   [:p (map segment->hiccup
            (-> message
-               (mp/parse)
+               (mp/parse2)
                (replace-ids-names usernames)))])
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/clj/clojurians_log/message_parser_test.clj
+++ b/test/clj/clojurians_log/message_parser_test.clj
@@ -1,5 +1,5 @@
 (ns clojurians-log.message-parser-test
-  (:require [clojurians-log.message-parser :refer [parse] :as sut]
+  (:require [clojurians-log.message-parser :refer [parse parse2] :as sut]
             [clojure.test :refer :all]))
 
 (deftest test-parse
@@ -47,3 +47,50 @@ please respond in <@C346HE24SD>"]
               [:undecorated "\nplease respond in "]
               [:channel-id "C346HE24SD"]]
              (parse message))))))
+
+
+(deftest test-parse2
+  (testing "basic messages"
+    (is (= [[:undecorated "This is a normal message"]]
+           (parse2 "This is a normal message")))
+    (is (= [[:user-id "U4F2A0Z8ER"]]
+           (parse2 "<@U4F2A0Z8ER>")))
+    (is (= [[:channel-id "C4F2A26SGSHBW"]]
+           (parse2 "<#C4F2A26SGSHBW>")))
+    (is (= [[:inline-code "DateTime"]]
+           (parse2 "`DateTime`")))
+    (is (= [[:code-block "(some clojure code)"]]
+           (parse2 "```(some clojure code)```")))
+    (is (= [[:bold "hey!"]]
+           (parse2 "*hey!*")))
+    (is (= [[:italic "hello"]]
+           (parse2 "_hello_")))
+    (is (= [[:emoji "thumbsup"]]
+           (parse2 ":thumbsup:")))
+    (is (= [[:undecorated "just_some_snake_case"]]
+           (parse2 "just_some_snake_case"))))
+
+  (testing "putting it together"
+    (let [message "Hey <@U4F2A0Z8ER>: here is the `my-ns.core` code ```
+  (let [code 42]
+   (inc code))
+```
+*what do* _you_ *think* :mindblown:
+please respond in <#C346HE24SD>"]
+      (is (= [[:undecorated "Hey "]
+              [:user-id "U4F2A0Z8ER"]
+              [:undecorated ": here is the "]
+              [:inline-code "my-ns.core"]
+              [:undecorated " code "]
+              [:code-block "(let [code 42]\n   (inc code))\n"]
+              [:undecorated "\n"]
+              [:bold "what do"]
+              [:undecorated " "]
+              [:italic "you"]
+              [:undecorated " "]
+              [:bold "think"]
+              [:undecorated " "]
+              [:emoji "mindblown"]
+              [:undecorated "\nplease respond in "]
+              [:channel-id "C346HE24SD"]]
+             (parse2 message))))))


### PR DESCRIPTION
As discussed in #32. It turns out the slack message format we're trying to parse isn't a very optimal use case for instaparse. 

Here's a first attempt at a parser that only makes use of regular expressions. In particular, this PR adds a creatively named `parse2` function to clojurians-log.message-parser. It mimicks the output of `parse` and should mostly be a drop-in replacement. At least it can pass all the same tests that `parse` passes.

---

Initial comparison indicates the new parser is roughly 100x faster than the old one. You can try this for yourself using the commented forms at the bottom of message_parser.clj.

On my machine, running `parse` over all messages on the "clojure" channel on 2018-02-02 took ~445ms. The `parse2` version took 4.3ms.

The routes where parse performance was initially discovered also completes in a much more reasonable time.

| route | time |
|------|------|
/clojure/2018-02-02 | 46.9 ms |
/clojure/2018-02-02/1517583973.000174 | 48.8 ms |

---

Tasks remaining:
- [ ] Integrate with existing user/channel reference parsing code (inline names already extracted)
- [ ] A lot more tests(?)

---

- [x] My code conforms to this project's [Style Guide](https://github.com/clojureverse/clojurians-log-app/blob/master/docs/STYLE.md)
- [x] I have added tests for functions or features I've added
- [x] All tests are green (`lein test`)
