### PR TITLE
Add logging Python script

### DIFF
--- a/bin/rtmbot.py
+++ b/bin/rtmbot.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+# Script that logs slack messages to text files. Configure with a "rtmbot.conf"
+# text file like this
+#
+#     SLACK_TOKEN: "xox-...."
+#     LOGFILE: /var/log/slackbot.log
+#     DAEMON: True
+#
+# Will create files like logs/2018-03-10.txt, containing one JSON object per
+# line, for each event. Will log all events received from the Slack RTM API
+# except for "pong", "hello", and "user_typing".
+
+import sys
+sys.dont_write_bytecode = True
+
+import glob
+import yaml
+import json
+import os
+import sys
+import time
+import logging
+
+from datetime import date
+from json import dumps
+import codecs
+
+from slackclient import SlackClient
+
+def process_message(data):
+    with codecs.open(date.today().strftime('logs/%Y-%m-%d.txt'), 'ab', 'utf-8') as f:
+        # print(dumps(data))
+        f.write(dumps(data))
+        f.write("\n")
+
+class RtmBot(object):
+    def __init__(self, token):
+        self.last_ping = 0
+        self.token = token
+        self.slack_client = None
+    def connect(self):
+        """Convenience method that creates Server instance"""
+        self.slack_client = SlackClient(self.token)
+        self.slack_client.rtm_connect()
+    def start(self):
+        self.connect()
+        while True:
+            for reply in self.slack_client.rtm_read():
+                self.input(reply)
+            self.autoping()
+            time.sleep(.1)
+    def autoping(self):
+        #hardcode the interval to 3 seconds
+        now = int(time.time())
+        if now > self.last_ping + 3:
+            self.slack_client.server.ping()
+            self.last_ping = now
+    def input(self, data):
+        if "type" in data and not data["type"] in {"pong", "user_typing", "hello"}:
+            process_message(data)
+
+def main_loop():
+    if "LOGFILE" in config:
+        logging.basicConfig(filename=config["LOGFILE"], level=logging.INFO, format='%(asctime)s %(message)s')
+    logging.info(directory)
+    try:
+        bot.start()
+    except KeyboardInterrupt:
+        sys.exit(0)
+    except:
+        logging.exception('OOPS')
+
+if __name__ == "__main__":
+    directory = os.path.dirname(sys.argv[0])
+    if not directory.startswith('/'):
+        directory = os.path.abspath("{}/{}".format(os.getcwd(),
+                                directory
+                                ))
+
+    config = yaml.load(file('rtmbot.conf', 'r'))
+    bot = RtmBot(config["SLACK_TOKEN"])
+    site_plugins = []
+    files_currently_downloading = []
+    job_hash = {}
+
+    if config.has_key("DAEMON"):
+        if config["DAEMON"]:
+            import daemon
+            with daemon.DaemonContext():
+                main_loop()
+    main_loop()


### PR DESCRIPTION
This is the script that does the actual logging, i.e. listening for events and
spitting out log files. It's a simplified version of the rtmbot.py that's part
of the original slack-archivist, adapted to be a single script, instead of the
original "plugin" system. It probably could be cleaned up further if anyone ever feels like doing so.

(see https://bitbucket.org/ul/slack-archivist /
https://github.com/plexus/slack-archivist)

Included in the repo here for completeness. We'll keep this bit in Python
because it works, it boots quickly, and it has low requirements, making it easy
to run it in multiple places to provide some redundance. Right now whenever the
server reboots we lose several minutes of messages, going forward we'll try to
prevent that.

This adapted version also differs in an important way from the version we've
been using so far: instead of only logging "message" events, it logs everything
except a few noisy and not very useful events: "pong", "user_typing" and
"hello".

This will give us some new possibilities to consider in the future, e.g. keeping
a user's data up to date automatically based on "user_change" events, display
"reactions" based on "reaction_added" events, stay up to date with custom
emoji ("emoji_changed"), file uploads, new channels, etc.
