### PR TITLE
Support channel renames

### DIFF
--- a/src/clj/clojurians_log/db/queries.clj
+++ b/src/clj/clojurians_log/db/queries.clj
@@ -95,3 +95,10 @@
          [?user :user/name ?username]]
        db
        names))
+
+(defn channel-id-map [db]
+  (into {}
+        (d/q '[:find ?slack-id ?chan
+               :where
+               [?chan :channel/slack-id ?slack-id]]
+             db)))

--- a/src/clj/clojurians_log/repl.clj
+++ b/src/clj/clojurians_log/repl.clj
@@ -4,6 +4,7 @@
   instance, or sys admins seeding the production system with data."
   (:require [clojurians-log.application :as app]
             [clojurians-log.slack-api :as slack]
+            [clojurians-log.db.queries :as q]
             [clojurians-log.db.import :as import]
             [clojurians-log.data :as data]
             [clojure.java.io :as io]

--- a/test/clj/clojurians_log/test_helper.clj
+++ b/test/clj/clojurians_log/test_helper.clj
@@ -23,14 +23,17 @@
   (doseq [tx txs]
     @(d/transact conn tx)))
 
+(defn test-conn []
+  (let [url (str "datomic:mem:" (gensym "test_db"))]
+    (d/create-database url)
+    (doto (d/connect url)
+      transact-schema)))
+
 (defn test-db
   ([]
    (test-db "two-channels-two-days"))
   ([fixture-name]
-   (let [url  (str "datomic:mem:" (gensym "test_db"))
-         _    (d/create-database url)
-         conn (d/connect url)]
-     (transact-schema conn)
+   (let [conn (test-conn)]
      (transact-txs conn (slurp-fixture fixture-name))
      [conn (d/db conn)])))
 


### PR DESCRIPTION
Channel renames were breaking the import, before importing new data we sync
channel data from slack, but both the slack-id and the channel name are consider
identities in datomic, and so trying to update a datom with the same slack-id
but different channel name caused datomic to look up one, and then complain
about the other one conflicting.

This change looks up the actual :db/id for those channels we already know about,
so that new ones get inserted, and renamed one get their new name applied.

This does mean that the log will only show the new name on old messages, not
necessarily the name that was present when the messages were posted.

<!--
Please write a short description of what your pull request does, as well as describing anything noteworthy about how you approached things.

Thank you for submitting a pull request! Someone will review your code, and if it all looks good, it will get merged.

People are granted commit right after they make a valuable contribution, but this does not mean you can push to master or merge your own commits. It does mean you can review other people's commits, and merge them if they look good.

Please give people a few days to respond. If you don't get any response within a few days, try politely asking people directly. Start with people who have worked on the same files/features, or who generally seem active here. If nobody responds, then ping @plexus :)
-->

- [x] My code conforms to this project's [Style Guide](https://github.com/clojureverse/clojurians-log-app/blob/master/docs/STYLE.md)
- [x] I have added tests for functions or features I've added
- [ ] All tests are green (`lein test`)
