### PR TITLE
Import threaded messages into the day of the thread

### DIFF
--- a/test/clj/clojurians_log/db/import_test.clj
+++ b/test/clj/clojurians_log/db/import_test.clj
@@ -1,0 +1,44 @@
+(ns clojurians-log.db.import-test
+  (:require [clojure.test :refer :all]
+            [clojurians-log.db.import :as import]))
+
+(deftest event->tx-test
+  (testing "returns valid datomic transaction data"
+    (is (= #:message{:key     "C0617A8PQ--1517728899.000025"
+                     :ts      "1517728899.000025"
+                     :day     "2018-02-04"
+                     :text    ":smile:"
+                     :channel [:channel/slack-id "C0617A8PQ"]
+                     :user    [:user/slack-id "U051BLM8F"]}
+           (import/event->tx {:source_team "T03RZGPFR"
+                              :text        ":smile:"
+                              :ts          "1517728899.000025"
+                              :user        "U051BLM8F"
+                              :team        "T03RZGPFR"
+                              :type        "message"
+                              :channel     "C0617A8PQ"}))))
+
+  (testing "parses thread info"
+    (is (= {:message/thread-ts   "1517483637.000077"
+            :message/thread-inst #inst "2018-02-01T11:13:57.000-00:00"}
+           (-> (import/event->tx {:source_team     "T03RZGPFR"
+                                  :reply_broadcast true
+                                  :channel         "C03S1L9DN"
+                                  :type            "message"
+                                  :thread_ts       "1517483637.000077"
+                                  :ts              "1517487432.000382"
+                                  :team            "T03RZGPFR"
+                                  :user            "U7THYHQ1F"
+                                  :text            "Wow, thanks!"})
+               (select-keys [:message/thread-ts :message/thread-inst])))))
+
+  (testing "puts threaded messages on the day of the thread"
+    (is (= "2018-02-06"
+           (:message/day (import/event->tx {:thread_ts   "1517932488.000769"
+                                            :source_team "T03RZGPFR"
+                                            :text        "posted on 2018-02-08, replying to a message from 2018-02-06"
+                                            :ts          "1518050759.000174"
+                                            :user        "U8MJBRSR5"
+                                            :team        "T03RZGPFR"
+                                            :type        "message"
+                                            :channel     "C03RZRRMP"}))))))


### PR DESCRIPTION
The concrete issue this solves is that we were seeing days in the listing for a
channel, that upon inspection didn't have any messages at all, because the
messages for those days were part of a thread that started on another day.

The :message/day field is really a denormalization to quickly determine on which
page to show a message, and so it makes sense to give threaded messages the
right :message/day immediately. This should allow simplifying some more queries,
this isn't yet part of this commit.

<!--
Please write a short description of what your pull request does, as well as describing anything noteworthy about how you approached things.

Thank you for submitting a pull request! Someone will review your code, and if it all looks good, it will get merged.

People are granted commit right after they make a valuable contribution, but this does not mean you can push to master or merge your own commits. It does mean you can review other people's commits, and merge them if they look good.

Please give people a few days to respond. If you don't get any response within a few days, try politely asking people directly. Start with people who have worked on the same files/features, or who generally seem active here. If nobody responds, then ping @plexus :)
-->

- [x] My code conforms to this project's [Style Guide](https://github.com/clojureverse/clojurians-log-app/blob/master/docs/STYLE.md)
- [x] I have added tests for functions or features I've added
- [x] All tests are green (`lein test`)
