### PR TITLE
Disable nested regions for urls

### DIFF
--- a/src/clj/clojurians_log/message_parser.clj
+++ b/src/clj/clojurians_log/message_parser.clj
@@ -167,7 +167,9 @@
   [stack match]
   (let [stack-top (last stack)]
     (if (or (= (:type stack-top) :code-block)
-            (= (:type stack-top) :inline-code))
+            (= (:type stack-top) :inline-code)
+            (= (:type stack-top) :url)
+            (= (:type stack-top) :emoji))
       false
       true)))
 

--- a/src/clj/clojurians_log/slack_api.clj
+++ b/src/clj/clojurians_log/slack_api.clj
@@ -18,7 +18,6 @@
 (defn import-users!
   ([conn]
    (import-users! conn (users)))
-
   ([conn users]
    (doseq [users (partition-all 1000 users)]
      @(d/transact conn (mapv import/user->tx users)))))
@@ -26,6 +25,5 @@
 (defn import-channels!
   ([conn]
    (import-channels! conn (channels)))
-
   ([conn channels]
    @(d/transact conn (mapv import/channel->tx channels))))

--- a/src/clj/clojurians_log/slack_api.clj
+++ b/src/clj/clojurians_log/slack_api.clj
@@ -15,9 +15,17 @@
 (defn channels []
   (:channels (slack-channels/list (conn))))
 
-(defn import-users! [conn]
-  (doseq [users (partition-all 1000 (users))]
-    @(d/transact conn (mapv import/user->tx users))))
+(defn import-users!
+  ([conn]
+   (import-users! conn (users)))
 
-(defn import-channels! [conn]
-  @(d/transact conn (mapv import/channel->tx (channels))))
+  ([conn users]
+   (doseq [users (partition-all 1000 users)]
+     @(d/transact conn (mapv import/user->tx users)))))
+
+(defn import-channels!
+  ([conn]
+   (import-channels! conn (channels)))
+
+  ([conn channels]
+   @(d/transact conn (mapv import/channel->tx channels))))

--- a/test/clj/clojurians_log/message_parser_test.clj
+++ b/test/clj/clojurians_log/message_parser_test.clj
@@ -178,4 +178,6 @@ please respond in <#C346HE24SD>"]
     ">>foo *_bar_*"      [[:blockquote [[:undecorated ">foo "] [:bold [:italic "bar"]]]]]
     "> >foo *_bar_*"     [[:undecorated "> >foo "] [:bold [:italic "bar"]]]
     ">>>a\nmultiline\nquote" [[:blockquote "a\nmultiline\nquote"]]
-    "<http://google.com|Google>" [[:url "http://google.com" "Google"]]))
+    "<http://google.com|Google>" [[:url "http://google.com" "Google"]]
+    "<https://clojure.org/reference/multimethods#_isa_based_dispatch>" [[:url "https://clojure.org/reference/multimethods#_isa_based_dispatch"]]
+    ))


### PR DESCRIPTION
Fixes #40 

The Bug
---

The minimal code the demonstrate this bug is:
```clojure
(clojurians-log.message-parser/parse2 "<https://clojure.org/reference/multimethods#_isa_based_dispatch>")
;;=> [[:url
;;    [[:undecorated "https://clojure.org/reference/multimethods#"]
;;     [:italic "isa"]
;;     [:undecorated "based_dispatch"]]]]
```

The parser attempts to process the url as styled text, which is obviously not the correct behavior.

---

What's included in the PR
---

1. Stop the parser from processing nested regions in urls
2. Stop the parser from processing nested regions in emojis (just in case)
3. Alternate demo data format
It was clear form the bug report that some message in the "clojurescript" channel on 2017-04-16 was causing an exception to be thrown. However, it was a little difficult to get those log messages into the app to get a reproducible failure case.

    When attempting to have the app import the 2017-04-16 messages using `clojurians-log.repl/load-demo-data!)`, datomic complained that messages were referencing non-existent users. As it turns out, the `user.edn` and `channels.edn` file in the demo data repo is a curated subset that contains only users and channels that are referenced in specific channels in a specific date range. So it is not possible to just drop a new log file into the demo data directory and expect to be able to load the messages into the app.

    https://github.com/clojureverse/clojurians-log-app/commit/7e042c37b12cfb231e11e232588d2c995c703138 includes an alternate `load-demo-data2!` function. It expects a "user.edn" and "channels.edn" file that are basically direct dumps from `clojurians-log.slack-api/users` and `clojurians-log.slack-api/channels`.

It's a simple change, but this should make bugs found in production much easier to reproduce.
---

- [x] My code conforms to this project's [Style Guide](https://github.com/clojureverse/clojurians-log-app/blob/master/docs/STYLE.md)
- [x] I have added tests for functions or features I've added
- [x] All tests are green (`lein test`)
