### PR TITLE
Fix exception when rendering message with nested styles

### DIFF
--- a/src/clj/clojurians_log/slack_messages.clj
+++ b/src/clj/clojurians_log/slack_messages.clj
@@ -35,6 +35,15 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Hiccup
 
+(defn- content-has-child-segments? [content]
+  (and (vector? content)
+       (vector? (first content))))
+
+(defn- transform-children-or-ident [f content]
+  (if (content-has-child-segments? content)
+    (map f content)
+    content))
+
 (defmulti segment->hiccup
   "Convert a single parsed segment of the form [type content] to hiccup."
   first)
@@ -60,10 +69,13 @@
   [:span.emoji ":" content ":"])
 
 (defmethod segment->hiccup :bold [[type content]]
-  [:b content])
+  [:b (transform-children-or-ident segment->hiccup content)])
 
 (defmethod segment->hiccup :italic [[type content]]
-  [:i content])
+  [:i (transform-children-or-ident segment->hiccup content)])
+
+(defmethod segment->hiccup :strike-through [[type content :as segment]]
+  [:del (transform-children-or-ident segment->hiccup content)])
 
 (defmethod segment->hiccup :url [[type content]]
   [:a {:href content} content])

--- a/test/clj/clojurians_log/slack_messages_test.clj
+++ b/test/clj/clojurians_log/slack_messages_test.clj
@@ -7,6 +7,18 @@
          (extract-user-ids
           [{:message/text "Hello <@ABC123>, how's <@ABC345|jonny> doing?"}]))))
 
+(deftest test-nested-styled-segment
+  (is (= (clojurians-log.slack-messages/segment->hiccup
+          [:strike-through
+           [[:undecorated "you can use "]
+            [:bold "::stest/opts"]
+            [:undecorated " and it’ll work"]]])
+
+         [:del
+          ["you can use "
+           [:b "::stest/opts"]
+           " and it’ll work"]])))
+
 (deftest test-render-hiccup
   (let [message "*Hey* <@U4F2A0Z8ER> how are things?"
         user-lookup {"U4F2A0Z8ER" "xandrews"}]


### PR DESCRIPTION
Fixes #43 

The Bug
---------

`clojurians-log.slack-messages/segment->hiccup` isn't able to deal with nested styles.

The specific message this fails on is
 ```<@U1G9D4WE7> I think <@U064X3EF3> is right. ~you can use `::stest/opts` and it’ll work~```

Minimal reproducible failure case:
```clojure
  (clojurians-log.slack-messages/segment->hiccup 
   [:strike-through
    [[:undecorated "you can use "]
     [:inline-code "::stest/opts"]
     [:undecorated " and it’ll work"]]])
```

--------

- [x] My code conforms to this project's [Style Guide](https://github.com/clojureverse/clojurians-log-app/blob/master/docs/STYLE.md)
- [x] I have added tests for functions or features I've added
- [x] All tests are green (`lein test`)
