### PR TITLE
Faster thread-message query

### DIFF
--- a/src/clj/clojurians_log/db/queries.clj
+++ b/src/clj/clojurians_log/db/queries.clj
@@ -95,3 +95,24 @@
          [?user :user/name ?username]]
        db
        names))
+
+(defn message-by-ts [db ts]
+  (d/q '[:find (pull ?msg [*]) .
+         :in $ ?ts
+         :where
+         [?msg :message/ts ?ts]]
+       db
+       ts))
+
+(defn thread-messages
+  "Retrieve all child messages for the given parent threads"
+  [db parent-tss]
+  (->> (d/q {:find [pull-message-pattern]
+             :in '[$ [?parent-ts ...]]
+             :where '[[?msg  :message/thread-ts ?parent-ts]]
+             }
+            db
+            parent-tss)
+
+       (map assoc-inst)
+       (sort-by :message/inst)))

--- a/src/clj/clojurians_log/routes.clj
+++ b/src/clj/clojurians_log/routes.clj
@@ -54,7 +54,7 @@
 
       (let [db       (d/db conn)
             messages (queries/channel-day-messages db channel date)
-            thread-messages (queries/channel-thread-messages-of-day db channel date)
+            thread-messages (queries/thread-messages db (map #(:message/ts %) messages))
             user-ids (slack-messages/extract-user-ids messages)]
 
         (if (empty? messages)

--- a/src/clj/clojurians_log/time_util.clj
+++ b/src/clj/clojurians_log/time_util.clj
@@ -73,3 +73,11 @@
 (defn within-interval [date [interval-start interval-end]]
   (and (.after date interval-start)
        (.before date interval-end)))
+
+(defmacro time-with-label
+  "Evaluates expr, prints the execution time with the supplied `label`, returns the value of expr."
+  [label expr]
+  `(let [start# (. System (nanoTime))
+         ret# ~expr]
+     (prn (str ~label ": " (/ (double (- (. System (nanoTime)) start#)) 1000000.0) " msecs"))
+     ret#))


### PR DESCRIPTION
This PR makes fetching thread messages much faster.

As mentioned in #39, the basic idea here is to write a new query that retrieves thread messages based on the :message/ts of the thread parents.

Quick measurement on the dev machine says, for http://localhost:4983/figwheel/2018-04-05, this change takes thread-message retrieval from 2356ms => 92ms.

Looks like the performance of the new query depends on how many potential parent threads we're asking to retrieve.

---

- [x] My code conforms to this project's [Style Guide](https://github.com/clojureverse/clojurians-log-app/blob/master/docs/STYLE.md)
- [ ] I have added tests for functions or features I've added
- [x] All tests are green (`lein test`)
