### PR TITLE
Return list of days with newest days first

### DIFF
--- a/src/clj/clojurians_log/db/queries.clj
+++ b/src/clj/clojurians_log/db/queries.clj
@@ -67,6 +67,12 @@
        (map assoc-inst)
        (sort-by :message/inst)))
 
+(defn reverse-compare
+  "Compares in the reverse order to clojure.core/compare.
+  Used to reverse result ordering."
+  [x y]
+  (compare y x))
+
 (defn channel-days [db chan-name]
   (->> (d/q '[:find ?day (count ?msg)
               :in $ ?chan-name
@@ -76,7 +82,7 @@
               [?msg :message/day ?day]]
             db
             chan-name)
-       (sort-by first)))
+       (sort-by first reverse-compare)))
 
 (defn channel [db name]
   (d/q '[:find (pull ?chan [*]) .


### PR DESCRIPTION
Most of the time, people browsing will prefer newer logs over older ones, this changes the sort order. I don't fully understand the wider context, so this may not be a safe change to make.