### PR TITLE
Add canonical rel for :log-target-message route

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ patches.
 - Andre R. (@rauhs)
 - Jonathan Chen (@dijonkitchen)
 - Daniel Compton (@danielcompton)
+- Daw-Ran Liou (@dawran6)
 
 ## Maintainers
 

--- a/src/clojurians_log/views.clj
+++ b/src/clojurians_log/views.clj
@@ -64,9 +64,10 @@
     ;; This allows external services to generate a preview/summary card of the page.
     (not (nil? target-message))
     (conj [:link {:rel "canonical" :href (bidi/path-for routes
-                                                        :log
+                                                        :log-target-message
                                                         :channel (:channel/name channel)
-                                                        :date date)}]
+                                                        :date date
+                                                        :ts (:message/ts target-message))}]
           [:meta {:property "og:title" :content (og-title context)}]
           [:meta {:property "og:type" :content "website"}]
           [:meta {:property "og:url" :content (str (url http-origin
@@ -79,7 +80,7 @@
           [:meta {:property "og:image:width" :content 50}]
           [:meta {:property "og:image:height" :content 50}]
           [:meta {:property "og:description" :content
-                   (slack-messages/message->text (:message/text target-message) usernames)}]
+                  (slack-messages/message->text (:message/text target-message) usernames)}]
           ;; Add javascript to jump to the targeted message when the page is finished loading
           [:script (hiccup.util/raw-string
                     (format


### PR DESCRIPTION
* Problem: pages don't have a canonical rel #58 
* Solution: add a `<link rel="canonical" href=".../" />` to the page `<head>`

<!--
This process uses the Collective Code Construction Contract
https://rfc.zeromq.org/spec:44/C4/

We merge quickly, but do keep a few things in mind

- make small PRs
- state the problem you are addressing (Problem: ... Solution: ...)
- add yourself to CONTRIBUTORS.md
- try not to break the build
-->
