### PR TITLE
Problem: canonical URLs are not absolute

### DIFF
--- a/src/clojurians_log/repl.clj
+++ b/src/clojurians_log/repl.clj
@@ -166,7 +166,11 @@
 
     [counter done?]))
 
-
+(comment
+  ;; Load https://github.com/clojureverse/clojurians-log-demo-data
+  (load-demo-data! "/home/arne/github/clojurians-log-demo-data")
+  (q/build-indexes! (d/db (conn)))
+  )
 
 (comment
   ;; rlwrap nc localhost 50505
@@ -187,10 +191,6 @@
   ;; incremental
   (load-from "2019-08-23")
 
-
-
-  (load-demo-data! "/home/arne/github/clojurians-log-demo-data")
-  (build-indexes! (d/db (conn)))
 
   (do
     (write-edn "users.edn" (slack/users))


### PR DESCRIPTION
Solution: add the origin (scheme+hostname) to make them absolute.

Google explicitly says canonical urls should be fully qualified, which kind of
makes sense.

https://support.google.com/webmasters/answer/139066?hl=en

<!--
This process uses the Collective Code Construction Contract
https://rfc.zeromq.org/spec:44/C4/

We merge quickly, but do keep a few things in mind

- make small PRs
- state the problem you are addressing (Problem: ... Solution: ...)
- add yourself to CONTRIBUTORS.md
- try not to break the build
-->
