### PR TITLE
Flip the time control arrows

### DIFF
--- a/src/clojurians_log/views.clj
+++ b/src/clojurians_log/views.clj
@@ -112,18 +112,18 @@
    [:div.channel-menu
     [:span.channel-menu_name [:span.channel-menu_prefix "#"] (:channel/name channel)]
     [:span.day-arrows
-     (if-let [prev-date (channel-day-offset channel-days date -1)]
+     (when-let [past-date (channel-day-offset channel-days date 1)]
        [:a {:href (bidi/path-for routes
                                  :log
                                  :channel (:channel/name channel)
-                                 :date prev-date)}
+                                 :date past-date)}
         [:div.day-prev "<"]])
      date
-     (if-let [next-date (channel-day-offset channel-days date 1)]
+     (when-let [future-date (channel-day-offset channel-days date -1)]
        [:a {:href (bidi/path-for routes
                                  :log
                                  :channel (:channel/name channel)
-                                 :date next-date)}
+                                 :date future-date)}
         [:div.day-next ">"]])]]])
 
 (defn- channel-list [{:data/keys [date channels]}]

--- a/test/clojurians_log/views_test.clj
+++ b/test/clojurians_log/views_test.clj
@@ -50,8 +50,8 @@
 
     (testing "It links to the front page and to prev/next days"
       (is (= [[:a {:href "/"} "Clojurians"]
-              [:a {:href "/clojure/2018-01-01"} [:div.day-prev "<"]]
-              [:a {:href "/clojure/2018-01-03"} [:div.day-next ">"]]]
+              [:a {:href "/clojure/2018-01-03"} [:div.day-prev "<"]]
+              [:a {:href "/clojure/2018-01-01"} [:div.day-next ">"]]]
              (html-select log-page [:a])))))
 
   (let [system (h/test-system)


### PR DESCRIPTION
Problem: #64 
Solution: Flip the hrefs of the two time control arrows. The left one goes into the past; the right one goes into the future. Rename the internal `let` binding to reflect this change.

<!--
This process uses the Collective Code Construction Contract
https://rfc.zeromq.org/spec:44/C4/

We merge quickly, but do keep a few things in mind

- make small PRs
- state the problem you are addressing (Problem: ... Solution: ...)
- add yourself to CONTRIBUTORS.md
- try not to break the build
-->
