### PR TITLE
Problem: clojure.pprint is not found

### DIFF
--- a/src/clojurians_log/message_parser.clj
+++ b/src/clojurians_log/message_parser.clj
@@ -136,7 +136,7 @@
 
     (and (token? tok1)
          (not (token? tok2)))
-    (apply conj [tok1] tok2)
+    (into [tok1] tok2)
 
     (and (not (token? tok1))
          (token? tok2))
@@ -144,15 +144,11 @@
 
     (and (not (token? tok1))
          (not (token? tok2)))
-    (apply conj tok1 tok2)
+    (into tok1 tok2)
 
     :else
     (do
-      (println "tok1")
-      (clojure.pprint/pprint tok1)
-      (println "tok2")
-      (clojure.pprint/pprint tok2)
-      (assert false "Unable to combine tokens"))))
+      (assert false (str "Unable to combine tokens:" (prn-str [tok1 tok2]))))))
 
 (defn- extract-undecorated-text [message start end]
   [:undecorated (replace-html-entities (subs message start end))])


### PR DESCRIPTION
This is causing the deployment to fail

Solution: remove the use of clojure.pprint, instead put the output as message
into the failing assertion.

Also cleans up `apply conj` => `into`

<!--
This process uses the Collective Code Construction Contract
https://rfc.zeromq.org/spec:44/C4/

We merge quickly, but do keep a few things in mind

- make small PRs
- state the problem you are addressing (Problem: ... Solution: ...)
- add yourself to CONTRIBUTORS.md
- try not to break the build
-->
