### PR TITLE
Render custom emojis

### DIFF
--- a/src/clojurians_log/db/import.clj
+++ b/src/clojurians_log/db/import.clj
@@ -83,9 +83,13 @@
 
 (defn channel->tx [{:keys [id name created creator]}]
   #:channel {:slack-id id
-             :name name
-             :created created
-             :creator [:user/slack-id creator]})
+             :name     name
+             :created  created
+             :creator  [:user/slack-id creator]})
+
+(defn emoji->tx [[shortcode url]]
+  #:emoji {:shortcode shortcode
+           :url       url})
 
 (defn lines-reducible [^BufferedReader rdr]
   (reify clojure.lang.IReduceInit

--- a/src/clojurians_log/db/import.clj
+++ b/src/clojurians_log/db/import.clj
@@ -88,7 +88,7 @@
              :creator  [:user/slack-id creator]})
 
 (defn emoji->tx [[shortcode url]]
-  #:emoji {:shortcode shortcode
+  #:emoji {:shortcode (name shortcode)
            :url       url})
 
 (defn lines-reducible [^BufferedReader rdr]

--- a/src/clojurians_log/db/queries.clj
+++ b/src/clojurians_log/db/queries.clj
@@ -143,6 +143,14 @@
                [?chan :channel/slack-id ?slack-id]]
              db)))
 
+(defn emoji-url-map [db]
+  (into {}
+        (d/q '[:find ?shortcode ?url
+               :where
+               [?emoji :emoji/shortcode ?shortcode]
+               [?emoji :emoji/url ?url]]
+             db)))
+
 #_
 (doseq [v [#'clojurians-log.db.queries/user-names
            #'clojurians-log.db.queries/channel-thread-messages-of-day

--- a/src/clojurians_log/db/schema.clj
+++ b/src/clojurians_log/db/schema.clj
@@ -149,7 +149,7 @@
 
 (def emoji-schema
   [#:db{:ident       :emoji/shortcode
-        :valueType   :db.type/keyword
+        :valueType   :db.type/string
         :cardinality :db.cardinality/one}
    #:db{:ident       :emoji/url
         :valueType   :db.type/string

--- a/src/clojurians_log/db/schema.clj
+++ b/src/clojurians_log/db/schema.clj
@@ -147,9 +147,18 @@
         :valueType   :db.type/ref
         :cardinality :db.cardinality/one}])
 
+(def emoji-schema
+  [#:db{:ident       :emoji/shortcode
+        :valueType   :db.type/keyword
+        :cardinality :db.cardinality/one}
+   #:db{:ident       :emoji/url
+        :valueType   :db.type/string
+        :cardinality :db.cardinality/one}])
+
 (def full-schema
   (concat message-schema
           event-schema
           user-schema
           user-profile-schema
-          channel-schema))
+          channel-schema
+          emoji-schema))

--- a/src/clojurians_log/repl.clj
+++ b/src/clojurians_log/repl.clj
@@ -16,8 +16,8 @@
 
 (Thread/setDefaultUncaughtExceptionHandler
  (reify Thread$UncaughtExceptionHandler
-	 (uncaughtException [_ thread throwable]
-		 (println (.getMessage throwable)))))
+   (uncaughtException [_ thread throwable]
+     (println (.getMessage throwable)))))
 
 (defn read-edn [filepath]
   (-> filepath
@@ -38,9 +38,10 @@
   (get-in (app/system) [:datomic :conn]))
 
 (defn load-slack-data!
-  "Import Slack users and Channels."
+  "Import Slack users, Channels, and custom emojis."
   []
   (slack/import-users! (conn))
+  (slack/import-emojis! (conn))
   (let [channel->db-id (q/channel-id-map (d/db (conn)))
         channels       (mapv import/channel->tx (slack/channels))]
     (d/transact (conn) (map (fn [{slack-id :channel/slack-id :as ch}]

--- a/src/clojurians_log/routes.clj
+++ b/src/clojurians_log/routes.clj
@@ -52,10 +52,10 @@
       (-> (ring.util.response/response nil)
           (ring.util.response/status 304))
 
-      (let [db       (d/db conn)
-            messages (queries/channel-day-messages db channel date)
+      (let [db              (d/db conn)
+            messages        (queries/channel-day-messages db channel date)
             thread-messages (queries/thread-messages db (map #(:message/ts %) messages))
-            user-ids (slack-messages/extract-user-ids messages)]
+            user-ids        (slack-messages/extract-user-ids messages)]
 
         (if (empty? messages)
           (-> (ring.util.response/response "Oops! No messages here!")
@@ -69,6 +69,7 @@
                      :data/messages (merge-thread-messages messages thread-messages)
                      :data/target-message (some #(when (= (:message/ts %) ts) %) (apply conj messages thread-messages))
                      :data/usernames (into {} (queries/user-names db user-ids))
+                     :data/emojis (queries/emoji-url-map db)
                      :data/channel-days (queries/channel-days db channel)
                      :data/title (str channel " " date " | Clojurians Slack Log")
                      :data/date date

--- a/src/clojurians_log/slack_api.clj
+++ b/src/clojurians_log/slack_api.clj
@@ -1,6 +1,7 @@
 (ns clojurians-log.slack-api
   (:require [clj-slack.users :as slack-users]
             [clj-slack.channels :as slack-channels]
+            [clj-slack.emoji :as slack-emoji]
             [datomic.api :as d]
             [clojurians-log.db.queries :as queries]
             [clojurians-log.db.import :as import]
@@ -15,6 +16,9 @@
 
 (defn channels []
   (:channels (slack-channels/list (slack-conn))))
+
+(defn emoji []
+  (:emoji (slack-emoji/list (slack-conn))))
 
 (defn import-users!
   ([conn]
@@ -32,3 +36,10 @@
                            (assoc ch :db/id db-id)
                            ch))
                        channels))))
+
+(defn import-emojis!
+  ([conn]
+   (import-emojis! conn (emoji)))
+  ([conn emojis]
+   (doseq [emojis (partition-all 1000 emojis)]
+     @(d/transact conn (mapv import/emoji->tx emojis)))))

--- a/src/clojurians_log/slack_messages.clj
+++ b/src/clojurians_log/slack_messages.clj
@@ -1,8 +1,5 @@
 (ns clojurians-log.slack-messages
   (:require [clojurians-log.message-parser :as mp]
-            #_[clojurians-log.application :as app]
-            #_[clojurians-log.db.queries :as q]
-            #_[datomic.api :as d]
             [clojure.string :as str]
             [hiccup2.core :as hiccup]
             [clojure.java.io :as io]

--- a/src/clojurians_log/slack_messages.clj
+++ b/src/clojurians_log/slack_messages.clj
@@ -124,12 +124,14 @@
 
 (defn message->hiccup
   "Parse slack markup and convert to hiccup."
-  [message usernames emojis]
-  [:p (map segment->hiccup
-           (-> message
-               (mp/parse2)
-               (replace-ids-names usernames)
-               (replace-custom-emojis emojis)))])
+  ([message usernames]
+   (message->hiccup message usernames {}))
+  ([message usernames emojis]
+   [:p (map segment->hiccup
+            (-> message
+                (mp/parse2)
+                (replace-ids-names usernames)
+                (replace-custom-emojis emojis)))]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Plain text

--- a/src/clojurians_log/styles.clj
+++ b/src/clojurians_log/styles.clj
@@ -27,6 +27,5 @@
   [:.message.thread-msg {:margin-left "1rem"}]
 
   [:.emoji
-   [:img {:height     "22px"
-          :width      "22px"
-          :margin-top "-11px"}]])
+   [:img {:height "22px"
+          :width  "22px"}]])

--- a/src/clojurians_log/styles.clj
+++ b/src/clojurians_log/styles.clj
@@ -24,4 +24,9 @@
    [:div.day-next (assoc small-square-button
                          :margin-left "0.3rem")]]
 
-  [:.message.thread-msg {:margin-left "1rem"}])
+  [:.message.thread-msg {:margin-left "1rem"}]
+
+  [:.emoji
+   [:img {:height     "22px"
+          :width      "22px"
+          :margin-top "-11px"}]])

--- a/src/clojurians_log/views.clj
+++ b/src/clojurians_log/views.clj
@@ -143,10 +143,10 @@
 
 (defn- single-message
   "Returns the hiccup of a single message"
-  [{:data/keys [usernames channel date hostname] :as context}
+  [{:data/keys [usernames channel date hostname emojis] :as context}
    {:message/keys [user inst user text thread-ts ts] :as message}]
 
-  (let [{:user/keys [name slack-id]
+  (let [{:user/keys         [name slack-id]
          :user-profile/keys [image-48]} user]
 
     ;; things in the profile
@@ -156,7 +156,7 @@
            {:id (cl.tu/format-inst-id inst) :class (when (thread-child? message) "thread-msg")}
            [:a.message_profile-pic {:href (str "https://clojurians.slack.com/team/" slack-id) :style (str "background-image: url(" image-48 ");")}]
            [:a.message_username {:href (str "https://clojurians.slack.com/team/" slack-id)} name]
-           [:span.message_timestamp [:a {:rel "nofollow"
+           [:span.message_timestamp [:a {:rel  "nofollow"
                                          :href (bidi/path-for routes
                                                               :log-target-message
                                                               :channel (:channel/name channel)
@@ -164,7 +164,7 @@
                                                               :ts ts)}
                                      (cl.tu/format-inst-time inst)]]
            [:span.message_star]
-           [:span.message_content [:p (slack-messages/message->hiccup text usernames)]]])))
+           [:span.message_content [:p (slack-messages/message->hiccup text usernames emojis)]]])))
 
 (defn- message-hiccup
   "Returns either a single message hiccup, or if the given message starts a thread,

--- a/test/clojurians_log/slack_messages_test.clj
+++ b/test/clojurians_log/slack_messages_test.clj
@@ -30,6 +30,21 @@
     (is (= [:p ["Thanks, I'm wonderful " [:span.emoji "😄"]]]
            (message->hiccup reply user-lookup)))))
 
+(deftest test-render-custom-emoji
+  (let [message-1 "Oh no, :facepalm:"
+        message-2 ":picard:"
+        emoji-map {"facepalm" "https://emoji/facepalm.png"
+                   "picard"   "alias:facepalm"}]
+    (is (= [:p
+            ["Oh no, "
+             [:span.emoji
+              [:img {:alt "facepalm" :src "https://emoji/facepalm.png"}]]]]
+           (message->hiccup message-1 {} emoji-map)))
+    (is (= [:p
+            [[:span.emoji
+              [:img {:alt "picard" :src "https://emoji/facepalm.png"}]]]]
+           (message->hiccup message-2 {} emoji-map)))))
+
 (deftest test-render-test
   (let [message     "*Hey* <@U4F2A0Z8ER> how are things?"
         user-lookup {"U4F2A0Z8ER" "xandrews"}]


### PR DESCRIPTION
This is still WIP.

Problem: #75 

Solution:


- [x] Get all custom emojis from slack api: `emoji.list`
- [x] Add Datomic schema for emojis
- [x] Import emojis to Datomic
- [x] Recursively resolve emoji alias/shortcode to its an url or an unicode
- [x] Render `img` tag for urls; plain string for unicodes
- [x] Add style for inline emoji `img` tag
- [x] Add tests
- [x] Pass emoji map to the render function

<!--
This process uses the Collective Code Construction Contract
https://rfc.zeromq.org/spec:44/C4/

We merge quickly, but do keep a few things in mind

- make small PRs
- state the problem you are addressing (Problem: ... Solution: ...)
- add yourself to CONTRIBUTORS.md
- try not to break the build
-->
