### PR TITLE
CircleCI: add the necessary clj aliases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,13 @@ commands:
           steps:
             - run: clojure -e '(println (System/getProperty "java.runtime.name") (System/getProperty "java.runtime.version") "\nClojure" (clojure-version))'
             - kaocha/execute:
+                aliases: "dev:datomic-free"
                 args: "unit --reporter documentation --plugin cloverage --codecov"
                 clojure_version: << parameters.clojure_version >>
             - kaocha/upload_codecov:
                 flags: unit
             - kaocha/execute:
+                aliases: "dev:datomic-free"
                 args: "integration --reporter documentation --plugin cloverage --codecov"
                 clojure_version: << parameters.clojure_version >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,6 @@ commands:
                 clojure_version: << parameters.clojure_version >>
             - kaocha/upload_codecov:
                 flags: unit
-            - kaocha/execute:
-                aliases: "dev:datomic-free"
-                args: "integration --reporter documentation --plugin cloverage --codecov"
-                clojure_version: << parameters.clojure_version >>
 
 jobs:
   java-11-clojure-1_10:


### PR DESCRIPTION
Problem: tests fail on CI because some namespaces aren't found

Solution: fix the configuration so it has the necessary aliases and thus classpath directories