### PR TITLE
change !indexes from {} to nil

### DIFF
--- a/profiles/dev/user.clj
+++ b/profiles/dev/user.clj
@@ -36,3 +36,11 @@
          [:message-page :cache-time]
          (constantly new-cache-time))
   true)
+
+(comment
+  (go)
+  (reset)
+  (reset-all)
+  (use 'clojurians-log.repl)
+  (load-demo-data! "../clojurians-log-demo-data")
+  #_:end)

--- a/src/clojurians_log/db/queries.clj
+++ b/src/clojurians_log/db/queries.clj
@@ -2,7 +2,7 @@
   (:require [clojurians-log.datomic :as d]
             [clojurians-log.time-util :as time-util]))
 
-(defonce !indexes (atom {}))
+(defonce !indexes (atom nil))
 
 (defn channels-dates-msgcounts [db]
   (d/q '[:find ?slack-id ?chan-name ?day (count ?msg)
@@ -23,7 +23,7 @@
            (assoc-in [:day-chan-cnt day slack-id] msgcount)
            (assoc-in [:chan-id->name slack-id] chan-name)
            (assoc-in [:chan-name->id chan-name] slack-id)))
-     {}
+     nil
      cdm)))
 
 (defn build-indexes! [db]


### PR DESCRIPTION
Solves #61 and adds some useful repl commands to user.clj . Concerning the comment "I think we need an (if channel-days ...) branch in log-page-header": I did not find a case where such an (if ...) was necessary, there were always the "Oops! No messages here!" and no 500 error. 