### PR TITLE
Canonicalize lib names in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,38 +3,38 @@
          org.clojure/clojure   {:mvn/version "1.10.1"}
          org.clojure/core.async {:mvn/version "0.7.559"}
 
-         environ                    {:mvn/version "1.1.0"}
-         aero                       {:mvn/version "1.1.4"}
+         environ/environ            {:mvn/version "1.1.0"}
+         aero/aero                  {:mvn/version "1.1.4"}
          com.stuartsierra/component {:mvn/version "0.4.0"}
          org.danielsz/system        {:mvn/version "0.4.4"}
 
          metosin/pohjavirta                   {:mvn/version "0.0.1-alpha7"}
-         ring                                 {:mvn/version "1.8.0"}
+         ring/ring                            {:mvn/version "1.8.0"}
          metosin/reitit                       {:mvn/version "0.4.2"}
          ring/ring-defaults                   {:mvn/version "0.3.2"}
          bk/ring-gzip                         {:mvn/version "0.3.0"}
          radicalzephyr/ring.middleware.logger {:mvn/version "0.6.0"}
-         hiccup                               {:mvn/version "2.0.0-alpha1"}
-         enlive                               {:mvn/version "1.1.6"}
+         hiccup/hiccup                        {:mvn/version "2.0.0-alpha1"}
+         enlive/enlive                        {:mvn/version "1.1.6"}
 
-         prone              {:mvn/version "2020-01-17"}
-         clj-logging-config {:mvn/version "1.9.12"}
+         prone/prone                           {:mvn/version "2020-01-17"}
+         clj-logging-config/clj-logging-config {:mvn/version "1.9.12"}
 
-         clojure.java-time         {:mvn/version "0.3.2"}
+         clojure.java-time/clojure.java-time   {:mvn/version "0.3.2"}
          com.cemerick/url          {:mvn/version "0.1.1"}
          com.cognitect/transit-clj {:mvn/version "0.8.319"}
-         clj-http                  {:mvn/version "3.10.0"}
+         clj-http/clj-http         {:mvn/version "3.10.0"}
          org.julienxx/clj-slack    {:mvn/version "0.6.3"}
 
-         lambdaisland/repl-tools {:mvn/version "0.1.0"}
-         reloaded.repl           {:mvn/version "0.2.4"}
-         markdown-to-hiccup {:mvn/version "0.6.2"}}
+         lambdaisland/repl-tools               {:mvn/version "0.1.0"}
+         reloaded.repl/reloaded.repl           {:mvn/version "0.2.4"}
+         markdown-to-hiccup/markdown-to-hiccup {:mvn/version "0.6.2"}}
 
  :aliases {:dev {:extra-paths ["profiles/dev"]
                  :extra-deps  {vvvvalvalval/scope-capture  {:mvn/version "0.3.2"}
-                               cheshire                    {:mvn/version "5.8.1"}
+                               cheshire/cheshire           {:mvn/version "5.8.1"}
                                ring/ring-mock              {:mvn/version "0.4.0"}
-                               hickory                     {:mvn/version "0.7.1"}
+                               hickory/hickory             {:mvn/version "0.7.1"}
                                lambdaisland/garden-watcher {:mvn/version "0.3.3"}
                                lambdaisland/kaocha         {:mvn/version "RELEASE"}}}
 


### PR DESCRIPTION
Unqualified lib names are being deprecated in deps.edn and will warn

<!--
This process uses the Collective Code Construction Contract
https://rfc.zeromq.org/spec:44/C4/

We merge quickly, but do keep a few things in mind

- make small PRs
- state the problem you are addressing (Problem: ... Solution: ...)
- add yourself to CONTRIBUTORS.md
- try not to break the build
-->
