### PR TITLE
Emoji reactions

### DIFF
--- a/bin/update_emoji_json
+++ b/bin/update_emoji_json
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+wget https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json -O resources/emojis.json

--- a/profiles/dev/user.clj
+++ b/profiles/dev/user.clj
@@ -1,6 +1,9 @@
 (ns user
   (:require [reloaded.repl :as reloaded]))
 
+(alter-var-root #'*print-namespace-maps* (constantly false))
+;; (set! *print-namespace-maps* false)
+
 (defmacro jit [sym]
   `(or (resolve '~sym)
        (do

--- a/repl/reactions.clj
+++ b/repl/reactions.clj
@@ -5,6 +5,7 @@
             [clojurians-log.db.queries :as q]
             [clojurians-log.db.import :as import]
             [clojurians-log.data :as data]
+            [clj-slack.emoji :as slack-emoji]
             [clojure.java.io :as io]
             [clojurians-log.datomic :as d]
             [clojure.tools.reader.edn :as edn]
@@ -15,10 +16,10 @@
 
 (d/q '[:find (pull ?m [* {:reaction/_message [{:reaction/emoji [:emoji/shortcode :emoji/url]}]}])
         :where
-        [?u :user/name "borkdude"]
-        [?m :message/day "2018-02-08"]
+        ;; [?u :user/name "borkdude"]
+        ;; [?m :message/day "2018-02-08"]
         [?m :message/channel ?chan]
-        [?chan :channel/name "aleph"]]
+        [?chan :channel/name "announcements"]]
       (db))
 
 (q/channel-day-messages (db) "aleph" "2018-02-08")
@@ -54,15 +55,30 @@
   (d/transact (conn) [{:emoji/shortcode "+1" :emoji/url "url1"}])
   (d/transact (conn) [{:emoji/shortcode "joy" :emoji/url "url1"}])
   (d/q '[:find (pull ?e [*]) :where [?e :emoji/shortcode]] (db))
+  (d/q '[:find (pull ?e [*]) :where [?e :emoji/shortcode "sheepy"]] (db))
   
   ;; add default emojis
   (def default-emojis
     (with-open [r (io/reader (io/resource "emojis.json"))]
       (let [emoji-list (-> (json/read r :key-fn keyword) :emojis)]
         (map #(hash-map :emoji/shortcode (:name %)) emoji-list))))
+  
+  (def emlist (with-open [r (io/reader (io/resource "emojis.json"))]
+                (let [emoji-list (-> (json/read r :key-fn keyword))]
+                  emoji-list)))
+  
+
+  (into {} (map (comp first #(for [alias (:aliases %)] [alias (:emoji %)])) emlist))
+  
   (d/transact (conn) default-emojis)
   (d/q '[:find (pull ?e [*]) :where [?e :emoji/shortcode]] (db))
   
+  (def emcoll (slack-emoji/list {:api-url "https://slack.com/api"
+   ;; TODO: get rid of this global config access
+                                 :token ""}))
+  
+  (doseq [emojis (partition-all 1000 (:emoji emcoll))]
+    @(d/transact (conn) (mapv import/emoji->tx emojis)))
   
   (load-demo-data! "../clojurians-log-demo-data2")
   )
@@ -83,6 +99,11 @@
                        :reaction/emoji [:emoji/shortcode "+1"]
                        :reaction/ts "1001"
                        :reaction/user [:user/name "plexus"]
-                       :reaction/message [:message/key "C0G922PCH--1518108773.000057"]}]))
+                       :reaction/message [:message/key "C0G922PCH--1518108773.000057"]}])
+  
+  (d/q '[:find (pull ?m [*])
+         :where
+         [?m :message/key "C0G922PCH--1518108773.000057"]]
+       (db)))
 
 

--- a/repl/reactions.clj
+++ b/repl/reactions.clj
@@ -1,0 +1,88 @@
+(ns repl.reactions
+  (:require [clojurians-log.application :as app]
+            [clojure.java.io :as io]
+            [clojurians-log.slack-api :as slack]
+            [clojurians-log.db.queries :as q]
+            [clojurians-log.db.import :as import]
+            [clojurians-log.data :as data]
+            [clojure.java.io :as io]
+            [clojurians-log.datomic :as d]
+            [clojure.tools.reader.edn :as edn]
+            [clojure.string :as str]
+            [clojure.core.async :as async :refer [>!! <! >! go-loop go <!!]]
+            [clojure.data.json :as json])
+  (:use [clojurians-log.repl]))
+
+(d/q '[:find (pull ?m [* {:reaction/_message [{:reaction/emoji [:emoji/shortcode :emoji/url]}]}])
+        :where
+        [?u :user/name "borkdude"]
+        [?m :message/day "2018-02-08"]
+        [?m :message/channel ?chan]
+        [?chan :channel/name "aleph"]]
+      (db))
+
+(q/channel-day-messages (db) "aleph" "2018-02-08")
+
+(d/q '[:find (pull ?r [*]) (pull ?m [*])
+       :where
+       [?u :user/name "borkdude"]
+       [?m :message/day "2018-02-08"]
+       [?m :message/channel ?chan]
+       [?chan :channel/name "aleph"]
+       [?r :reaction/message ?m]]
+     (db))
+
+(d/q '[:find ?m ?r
+       :where
+       [?r :reaction/message ?m]]
+     (db))
+
+(d/q '[:find (pull ?r [*])
+       :where
+       [?r :reaction/type]]
+     (db))
+
+;; find a message by key
+(d/q '[:find (pull ?m [*])
+       :where
+       [?m :message/key "C0E1SN0NM--1604347443.149900"]]
+     (db))
+
+
+(comment
+  ;; add some emojis
+  (d/transact (conn) [{:emoji/shortcode "+1" :emoji/url "url1"}])
+  (d/transact (conn) [{:emoji/shortcode "joy" :emoji/url "url1"}])
+  (d/q '[:find (pull ?e [*]) :where [?e :emoji/shortcode]] (db))
+  
+  ;; add default emojis
+  (def default-emojis
+    (with-open [r (io/reader (io/resource "emojis.json"))]
+      (let [emoji-list (-> (json/read r :key-fn keyword) :emojis)]
+        (map #(hash-map :emoji/shortcode (:name %)) emoji-list))))
+  (d/transact (conn) default-emojis)
+  (d/q '[:find (pull ?e [*]) :where [?e :emoji/shortcode]] (db))
+  
+  
+  (load-demo-data! "../clojurians-log-demo-data2")
+  )
+
+(comment
+  (d/q '[:find ?eid :in $ ?eid :where [?eid]] (db) 17592186091857))
+
+(comment
+  (d/transact (conn) [{:db/id 17592186091852 :emoji/shortcode "joy" :emoji/url "url1"}])
+
+  (d/transact (conn) [{:db/ident       :emoji/shortcode
+                       :db/index true}])
+
+  (d/transact (conn) [{:db/ident       :emoji/shortcode
+                       :db/unique      :db.unique/identity}])
+
+  (d/transact (conn) [{:reaction/type "reaction_added"
+                       :reaction/emoji [:emoji/shortcode "+1"]
+                       :reaction/ts "1001"
+                       :reaction/user [:user/name "plexus"]
+                       :reaction/message [:message/key "C0G922PCH--1518108773.000057"]}]))
+
+

--- a/resources/emojis.json
+++ b/resources/emojis.json
@@ -1,1810 +1,22653 @@
-{
-	"emojis": [
-		{"emoji": "👩‍👩‍👧‍👧", "name": "family_mothers_two_girls", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#128105;&zwj;&#128103;&zwj;&#128103;", "category": "p", "order": ""},
-		{"emoji": "👩‍👩‍👧‍👦", "name": "family_mothers_children", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#128105;&zwj;&#128103;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👩‍👩‍👦‍👦", "name": "family_mothers_two_boys", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#128105;&zwj;&#128102;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👨‍👩‍👧‍👧", "name": "family_two_girls", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128105;&zwj;&#128103;&zwj;&#128103;", "category": "p", "order": ""},
-		{"emoji": "👨‍👩‍👧‍👦", "name": "family_children", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128105;&zwj;&#128103;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👨‍👩‍👦‍👦", "name": "family_two_boys", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128105;&zwj;&#128102;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👨‍👨‍👧‍👧", "name": "family_fathers_two_girls", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128104;&zwj;&#128103;&zwj;&#128103;", "category": "p", "order": ""},
-		{"emoji": "👨‍👨‍👧‍👦", "name": "family_fathers_children", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128104;&zwj;&#128103;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👨‍👨‍👦‍👦", "name": "family_fathers_two_boys", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128104;&zwj;&#128102;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👩‍👩‍👧", "name": "family_mothers_one_girl", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#128105;&zwj;&#128103;", "category": "p", "order": ""},
-		{"emoji": "👩‍👩‍👦", "name": "family_mothers_one_boy", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#128105;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👩‍👧‍👧", "name": "single_mother_two_girls", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#128103;&zwj;&#128103;", "category": "p", "order": ""},
-		{"emoji": "👩‍👧‍👦", "name": "single_mother_two_children", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#128103;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👩‍👦‍👦", "name": "single_mother_two_boys", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#128102;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👨‍👩‍👧", "name": "family_one_girl", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128105;&zwj;&#128103;", "category": "p", "order": ""},
-		{"emoji": "👨‍👨‍👧", "name": "family_fathers_one_girl", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128104;&zwj;&#128103;", "category": "p", "order": ""},
-		{"emoji": "👨‍👨‍👦", "name": "family_fathers_one_boy", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128104;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👨‍👧‍👧", "name": "single_father_two_girls", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128103;&zwj;&#128103;", "category": "p", "order": ""},
-		{"emoji": "👨‍👧‍👦", "name": "single_father_with_children", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128103;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👨‍👦‍👦", "name": "single_father_two_boys", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128102;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👩‍👧", "name": "single_mother_one_girl", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#128103;", "category": "p", "order": ""},
-		{"emoji": "👩‍👦", "name": "single_mother_one_boy", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "👨‍👧", "name": "single_father_one_girl", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128103;", "category": "p", "order": ""},
-		{"emoji": "👨‍👦", "name": "single_father_one_boy", "shortname": "", "unicode": "", "html": "&#128104;&zwj;&#128102;", "category": "p", "order": ""},
-		{"emoji": "😂", "name": "joy", "shortname": ":joy:", "unicode": "1f602", "html": "&#128514;", "category": "p", "order": "3"},
-		{"emoji": "❤️", "name": "heart", "shortname": ":heart:", "unicode": "2764", "html": "&#10084;", "category": "s", "order": "1286"},
-		{"emoji": "♥️", "name": "", "shortname": "", "unicode": "", "html": "&hearts;️", "category": "", "order": ""},
-		{"emoji": "😍", "name": "heart_eyes", "shortname": ":heart_eyes:", "unicode": "1f60d", "html": "&#128525;", "category": "p", "order": "13"},
-		{"emoji": "😭", "name": "sob", "shortname": ":sob:", "unicode": "1f62d", "html": "&#128557;", "category": "p", "order": "55"},
-		{"emoji": "😊", "name": "blush", "shortname": ":blush:", "unicode": "1f60a", "html": "&#128522;", "category": "p", "order": "10"},
-		{"emoji": "😒", "name": "unamused", "shortname": ":unamused:", "unicode": "1f612", "html": "&#128530;", "category": "p", "order": "41"},
-		{"emoji": "😘", "name": "kissing_heart", "shortname": ":kissing_heart:", "unicode": "1f618", "html": "&#128536;", "category": "p", "order": "14"},
-		{"emoji": "💕", "name": "two_hearts", "shortname": ":two_hearts:", "unicode": "1f495", "html": "&#128149;", "category": "s", "order": "1289"},
-		{"emoji": "☺️", "name": "white smiling face", "shortname": ":smiling:", "unicode": "", "html": "&#9786;", "category": "", "order": ""},
-		{"emoji": "😩", "name": "weary", "shortname": ":weary:", "unicode": "1f629", "html": "&#128553;", "category": "p", "order": "59"},
-		{"emoji": "👌🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128076;&#127999;", "category": "", "order": ""},
-		{"emoji": "👌🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128076;&#127998;", "category": "", "order": ""},
-		{"emoji": "👌🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128076;&#127997;", "category": "", "order": ""},
-		{"emoji": "👌🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128076;&#127996;", "category": "", "order": ""},
-		{"emoji": "👌🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128076;&#127995;", "category": "", "order": ""},
-		{"emoji": "👌", "name": "ok_hand", "shortname": ":ok_hand:", "unicode": "1f44c", "html": "&#128076;", "category": "p", "order": "1170"},
-		{"emoji": "😔", "name": "pensive", "shortname": ":pensive:", "unicode": "1f614", "html": "&#128532;", "category": "p", "order": "43"},
-		{"emoji": "😏", "name": "smirk", "shortname": ":smirk:", "unicode": "1f60f", "html": "&#128527;", "category": "p", "order": "26"},
-		{"emoji": "😁", "name": "grin", "shortname": ":grin:", "unicode": "1f601", "html": "&#128513;", "category": "p", "order": "2"},
-		{"emoji": "♻", "name": "recycle", "shortname": ":recycle:", "unicode": "267b", "html": "&#9851;", "category": "s", "order": "2072"},
-		{"emoji": "😉", "name": "wink", "shortname": ":wink:", "unicode": "1f609", "html": "&#128521;", "category": "p", "order": "9"},
-		{"emoji": "👍🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128077;&#127999;", "category": "", "order": ""},
-		{"emoji": "👍🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128077;&#127998;", "category": "", "order": ""},
-		{"emoji": "👍🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128077;&#127997;", "category": "", "order": ""},
-		{"emoji": "👍🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128077;&#127996;", "category": "", "order": ""},
-		{"emoji": "👍🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128077;&#127995;", "category": "", "order": ""},
-		{"emoji": "👍", "name": "thumbsup", "shortname": ":thumbsup:", "unicode": "1f44d", "html": "&#128077;", "category": "p", "order": "1176"},
-		{"emoji": "🙏🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128591;&#127999;", "category": "", "order": ""},
-		{"emoji": "🙏🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128591;&#127998;", "category": "", "order": ""},
-		{"emoji": "🙏🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128591;&#127997;", "category": "", "order": ""},
-		{"emoji": "🙏🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128591;&#127996;", "category": "", "order": ""},
-		{"emoji": "🙏🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128591;&#127995;", "category": "", "order": ""},
-		{"emoji": "🙏", "name": "pray", "shortname": ":pray:", "unicode": "1f64f", "html": "&#128591;", "category": "p", "order": "1248"},
-		{"emoji": "😌", "name": "relieved", "shortname": ":relieved:", "unicode": "1f60c", "html": "&#128524;", "category": "p", "order": "35"},
-		{"emoji": "🎶", "name": "notes", "shortname": ":notes:", "unicode": "1f3b6", "html": "&#127926;", "category": "s", "order": "1825"},
-		{"emoji": "😳", "name": "flushed", "shortname": ":flushed:", "unicode": "1f633", "html": "&#128563;", "category": "p", "order": "63"},
-		{"emoji": "🙌🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128588;&#127999;", "category": "", "order": ""},
-		{"emoji": "🙌🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128588;&#127998;", "category": "", "order": ""},
-		{"emoji": "🙌🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128588;&#127997;", "category": "", "order": ""},
-		{"emoji": "🙌🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128588;&#127996;", "category": "", "order": ""},
-		{"emoji": "🙌🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128588;&#127995;", "category": "", "order": ""},
-		{"emoji": "🙌", "name": "raised_hands", "shortname": ":raised_hands:", "unicode": "1f64c", "html": "&#128588;", "category": "p", "order": "1242"},
-		{"emoji": "🙈", "name": "see_no_evil", "shortname": ":see_no_evil:", "unicode": "1f648", "html": "&#128584;", "category": "n", "order": "96"},
-		{"emoji": "😢", "name": "cry", "shortname": ":cry:", "unicode": "1f622", "html": "&#128546;", "category": "p", "order": "54"},
-		{"emoji": "😎", "name": "sunglasses", "shortname": ":sunglasses:", "unicode": "1f60e", "html": "&#128526;", "category": "p", "order": "12"},
-		{"emoji": "✌🏿", "name": "", "shortname": "", "unicode": "", "html": "&#9996;&#127999;", "category": "", "order": ""},
-		{"emoji": "✌🏾", "name": "", "shortname": "", "unicode": "", "html": "&#9996;&#127998;", "category": "", "order": ""},
-		{"emoji": "✌🏽", "name": "", "shortname": "", "unicode": "", "html": "&#9996;&#127997;", "category": "", "order": ""},
-		{"emoji": "✌🏼", "name": "", "shortname": "", "unicode": "", "html": "&#9996;&#127996;", "category": "", "order": ""},
-		{"emoji": "✌🏻", "name": "", "shortname": "", "unicode": "", "html": "&#9996;&#127995;", "category": "", "order": ""},
-		{"emoji": "✌️", "name": "v", "shortname": ":v:", "unicode": "270c", "html": "&#9996;", "category": "p", "order": "1128"},
-		{"emoji": "👀", "name": "eyes", "shortname": ":eyes:", "unicode": "1f440", "html": "&#128064;", "category": "p", "order": "1279"},
-		{"emoji": "😅", "name": "sweat_smile", "shortname": ":sweat_smile:", "unicode": "1f605", "html": "&#128517;", "category": "p", "order": "7"},
-		{"emoji": "✨", "name": "sparkles", "shortname": ":sparkles:", "unicode": "2728", "html": "&#10024;", "category": "n", "order": "1760"},
-		{"emoji": "😴", "name": "sleeping", "shortname": ":sleeping:", "unicode": "1f634", "html": "&#128564;", "category": "p", "order": "34"},
-		{"emoji": "😄", "name": "smile", "shortname": ":smile:", "unicode": "1f604", "html": "&#128516;", "category": "p", "order": "6"},
-		{"emoji": "💜", "name": "purple_heart", "shortname": ":purple_heart:", "unicode": "1f49c", "html": "&#128156;", "category": "s", "order": "1295"},
-		{"emoji": "💔", "name": "broken_heart", "shortname": ":broken_heart:", "unicode": "1f494", "html": "&#128148;", "category": "s", "order": "1288"},
-		{"emoji": "💯", "name": "100", "shortname": "", "unicode": "", "html": "&#128175;", "category": "", "order": ""},
-		{"emoji": "😑", "name": "expressionless", "shortname": ":expressionless:", "unicode": "1f611", "html": "&#128529;", "category": "p", "order": "23"},
-		{"emoji": "💖", "name": "sparkling_heart", "shortname": ":sparkling_heart:", "unicode": "1f496", "html": "&#128150;", "category": "s", "order": "1290"},
-		{"emoji": "💙", "name": "blue_heart", "shortname": ":blue_heart:", "unicode": "1f499", "html": "&#128153;", "category": "s", "order": "1292"},
-		{"emoji": "😕", "name": "confused", "shortname": ":confused:", "unicode": "1f615", "html": "&#128533;", "category": "p", "order": "44"},
-		{"emoji": "💁🏿‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&#127999;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💁🏾‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&#127998;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💁🏽‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&#127997;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💁🏼‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&#127996;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💁🏻‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&#127995;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💁‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💁🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&#127999;", "category": "", "order": ""},
-		{"emoji": "💁🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&#127998;", "category": "", "order": ""},
-		{"emoji": "💁🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&#127997;", "category": "", "order": ""},
-		{"emoji": "💁🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&#127996;", "category": "", "order": ""},
-		{"emoji": "💁🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128129;&#127995;", "category": "", "order": ""},
-		{"emoji": "💁", "name": "information_desk_person", "shortname": ":information_desk_person:", "unicode": "1f481", "html": "&#128129;", "category": "p", "order": "567"},
-		{"emoji": "😜", "name": "stuck_out_tongue_winking_eye", "shortname": ":stuck_out_tongue_winking_eye:", "unicode": "1f61c", "html": "&#128540;", "category": "p", "order": "38"},
-		{"emoji": "😞", "name": "disappointed", "shortname": ":disappointed:", "unicode": "1f61e", "html": "&#128542;", "category": "p", "order": "51"},
-		{"emoji": "😋", "name": "yum", "shortname": ":yum:", "unicode": "1f60b", "html": "&#128523;", "category": "p", "order": "11"},
-		{"emoji": "😐", "name": "neutral_face", "shortname": ":neutral_face:", "unicode": "1f610", "html": "&#128528;", "category": "p", "order": "22"},
-		{"emoji": "😪", "name": "sleepy", "shortname": ":sleepy:", "unicode": "1f62a", "html": "&#128554;", "category": "p", "order": "32"},
-		{"emoji": "👏🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128079;&#127999;", "category": "", "order": ""},
-		{"emoji": "👏🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128079;&#127998;", "category": "", "order": ""},
-		{"emoji": "👏🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128079;&#127997;", "category": "", "order": ""},
-		{"emoji": "👏🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128079;&#127996;", "category": "", "order": ""},
-		{"emoji": "👏🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128079;&#127995;", "category": "", "order": ""},
-		{"emoji": "👏", "name": "clap", "shortname": ":clap:", "unicode": "1f44f", "html": "&#128079;", "category": "p", "order": "1224"},
-		{"emoji": "💘", "name": "cupid", "shortname": ":cupid:", "unicode": "1f498", "html": "&#128152;", "category": "s", "order": "1285"},
-		{"emoji": "💗", "name": "heartpulse", "shortname": ":heartpulse:", "unicode": "1f497", "html": "&#128151;", "category": "s", "order": "1291"},
-		{"emoji": "💞", "name": "revolving_hearts", "shortname": ":revolving_hearts:", "unicode": "1f49e", "html": "&#128158;", "category": "s", "order": "1298"},
-		{"emoji": "⬅️", "name": "arrow_left", "shortname": ":arrow_left:", "unicode": "2b05", "html": "&#11013;", "category": "s", "order": "2008"},
-		{"emoji": "🙊", "name": "speak_no_evil", "shortname": ":speak_no_evil:", "unicode": "1f64a", "html": "&#128586;", "category": "n", "order": "98"},
-		{"emoji": "✋🏿", "name": "", "shortname": "", "unicode": "", "html": "&#9995;&#127999;", "category": "", "order": ""},
-		{"emoji": "✋🏾", "name": "", "shortname": "", "unicode": "", "html": "&#9995;&#127998;", "category": "", "order": ""},
-		{"emoji": "✋🏽", "name": "", "shortname": "", "unicode": "", "html": "&#9995;&#127997;", "category": "", "order": ""},
-		{"emoji": "✋🏼", "name": "", "shortname": "", "unicode": "", "html": "&#9995;&#127996;", "category": "", "order": ""},
-		{"emoji": "✋🏻", "name": "", "shortname": "", "unicode": "", "html": "&#9995;&#127995;", "category": "", "order": ""},
-		{"emoji": "✋", "name": "", "shortname": "", "unicode": "", "html": "&#9995;", "category": "", "order": ""},
-		{"emoji": "💋", "name": "kiss", "shortname": ":kiss:", "unicode": "1f48b", "html": "&#128139;", "category": "p", "order": "1284"},
-		{"emoji": "👉🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128073;&#127999;", "category": "", "order": ""},
-		{"emoji": "👉🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128073;&#127998;", "category": "", "order": ""},
-		{"emoji": "👉🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128073;&#127997;", "category": "", "order": ""},
-		{"emoji": "👉🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128073;&#127996;", "category": "", "order": ""},
-		{"emoji": "👉🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128073;&#127995;", "category": "", "order": ""},
-		{"emoji": "👉", "name": "point_right", "shortname": ":point_right:", "unicode": "1f449", "html": "&#128073;", "category": "p", "order": "1098"},
-		{"emoji": "🌸", "name": "cherry_blossom", "shortname": ":cherry_blossom:", "unicode": "1f338", "html": "&#127800;", "category": "n", "order": "1428"},
-		{"emoji": "😱", "name": "scream", "shortname": ":scream:", "unicode": "1f631", "html": "&#128561;", "category": "p", "order": "62"},
-		{"emoji": "🔥", "name": "fire", "shortname": ":fire:", "unicode": "1f525", "html": "&#128293;", "category": "n", "order": "1753"},
-		{"emoji": "😡", "name": "rage", "shortname": ":rage:", "unicode": "1f621", "html": "&#128545;", "category": "p", "order": "65"},
-		{"emoji": "😃", "name": "smiley", "shortname": ":smiley:", "unicode": "1f603", "html": "&#128515;", "category": "p", "order": "5"},
-		{"emoji": "🎉", "name": "tada", "shortname": ":tada:", "unicode": "1f389", "html": "&#127881;", "category": "o", "order": "1762"},
-		{"emoji": "👊🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128074;&#127999;", "category": "", "order": ""},
-		{"emoji": "👊🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128074;&#127998;", "category": "", "order": ""},
-		{"emoji": "👊🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128074;&#127997;", "category": "", "order": ""},
-		{"emoji": "👊🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128074;&#127996;", "category": "", "order": ""},
-		{"emoji": "👊🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128074;&#127995;", "category": "", "order": ""},
-		{"emoji": "👊", "name": "", "shortname": "", "unicode": "", "html": "&#128074;", "category": "", "order": ""},
-		{"emoji": "😫", "name": "tired_face", "shortname": ":tired_face:", "unicode": "1f62b", "html": "&#128555;", "category": "p", "order": "33"},
-		{"emoji": "📷", "name": "camera", "shortname": ":camera:", "unicode": "1f4f7", "html": "&#128247;", "category": "o", "order": "1861"},
-		{"emoji": "🌹", "name": "rose", "shortname": ":rose:", "unicode": "1f339", "html": "&#127801;", "category": "n", "order": "1431"},
-		{"emoji": "😝", "name": "stuck_out_tongue_closed_eyes", "shortname": ":stuck_out_tongue_closed_eyes:", "unicode": "1f61d", "html": "&#128541;", "category": "p", "order": "39"},
-		{"emoji": "💪🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128170;&#127999;", "category": "", "order": ""},
-		{"emoji": "💪🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128170;&#127998;", "category": "", "order": ""},
-		{"emoji": "💪🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128170;&#127997;", "category": "", "order": ""},
-		{"emoji": "💪🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128170;&#127996;", "category": "", "order": ""},
-		{"emoji": "💪🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128170;&#127995;", "category": "", "order": ""},
-		{"emoji": "💪", "name": "muscle", "shortname": ":muscle:", "unicode": "1f4aa", "html": "&#128170;", "category": "p", "order": "1080"},
-		{"emoji": "💀", "name": "skull", "shortname": ":skull:", "unicode": "1f480", "html": "&#128128;", "category": "p", "order": "80"},
-		{"emoji": "☀️", "name": "sunny", "shortname": ":sunny:", "unicode": "2600", "html": "&#9728;", "category": "n", "order": "1724"},
-		{"emoji": "💛", "name": "yellow_heart", "shortname": ":yellow_heart:", "unicode": "1f49b", "html": "&#128155;", "category": "s", "order": "1294"},
-		{"emoji": "😤", "name": "triumph", "shortname": ":triumph:", "unicode": "1f624", "html": "&#128548;", "category": "p", "order": "53"},
-		{"emoji": "🌚", "name": "new_moon_with_face", "shortname": ":new_moon_with_face:", "unicode": "1f31a", "html": "&#127770;", "category": "n", "order": "1720"},
-		{"emoji": "😆", "name": "laughing", "shortname": ":laughing:", "unicode": "1f606", "html": "&#128518;", "category": "p", "order": "8"},
-		{"emoji": "😓", "name": "sweat", "shortname": ":sweat:", "unicode": "1f613", "html": "&#128531;", "category": "p", "order": "42"},
-		{"emoji": "👈🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128072;&#127999;", "category": "", "order": ""},
-		{"emoji": "👈🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128072;&#127998;", "category": "", "order": ""},
-		{"emoji": "👈🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128072;&#127997;", "category": "", "order": ""},
-		{"emoji": "👈🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128072;&#127996;", "category": "", "order": ""},
-		{"emoji": "👈🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128072;&#127995;", "category": "", "order": ""},
-		{"emoji": "👈", "name": "point_left", "shortname": ":point_left:", "unicode": "1f448", "html": "&#128072;", "category": "p", "order": "1092"},
-		{"emoji": "✔️", "name": "heavy_check_mark", "shortname": ":heavy_check_mark:", "unicode": "2714", "html": "&#10004;", "category": "s", "order": "2080"},
-		{"emoji": "😻", "name": "heart_eyes_cat", "shortname": ":heart_eyes_cat:", "unicode": "1f63b", "html": "&#128571;", "category": "p", "order": "90"},
-		{"emoji": "😀", "name": "grinning", "shortname": ":grinning:", "unicode": "1f600", "html": "&#128512;", "category": "p", "order": "1"},
-		{"emoji": "😷", "name": "mask", "shortname": ":mask:", "unicode": "1f637", "html": "&#128567;", "category": "p", "order": "71"},
-		{"emoji": "💚", "name": "green_heart", "shortname": ":green_heart:", "unicode": "1f49a", "html": "&#128154;", "category": "s", "order": "1293"},
-		{"emoji": "👋🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128075;&#127999;", "category": "", "order": ""},
-		{"emoji": "👋🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128075;&#127998;", "category": "", "order": ""},
-		{"emoji": "👋🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128075;&#127997;", "category": "", "order": ""},
-		{"emoji": "👋🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128075;&#127996;", "category": "", "order": ""},
-		{"emoji": "👋🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128075;&#127995;", "category": "", "order": ""},
-		{"emoji": "👋", "name": "wave", "shortname": ":wave:", "unicode": "1f44b", "html": "&#128075;", "category": "p", "order": "1218"},
-		{"emoji": "😣", "name": "persevere", "shortname": ":persevere:", "unicode": "1f623", "html": "&#128547;", "category": "p", "order": "27"},
-		{"emoji": "💓", "name": "heartbeat", "shortname": ":heartbeat:", "unicode": "1f493", "html": "&#128147;", "category": "s", "order": "1287"},
-		{"emoji": "▶️", "name": "arrow_forward", "shortname": ":arrow_forward:", "unicode": "25b6", "html": "&#9654;", "category": "s", "order": "2051"},
-		{"emoji": "◀️", "name": "arrow_backward", "shortname": ":arrow_backward:", "unicode": "25c0", "html": "&#9664;", "category": "s", "order": "2055"},
-		{"emoji": "↪️", "name": "arrow_right_hook", "shortname": ":arrow_right_hook:", "unicode": "21aa", "html": "&#8618;", "category": "s", "order": "2013"},
-		{"emoji": "↩️", "name": "leftwards_arrow_with_hook", "shortname": ":leftwards_arrow_with_hook:", "unicode": "21a9", "html": "&#8617;", "category": "s", "order": "2012"},
-		{"emoji": "👑", "name": "crown", "shortname": ":crown:", "unicode": "1f451", "html": "&#128081;", "category": "p", "order": "1333"},
-		{"emoji": "😚", "name": "kissing_closed_eyes", "shortname": ":kissing_closed_eyes:", "unicode": "1f61a", "html": "&#128538;", "category": "p", "order": "17"},
-		{"emoji": "😛", "name": "stuck_out_tongue", "shortname": ":stuck_out_tongue:", "unicode": "1f61b", "html": "&#128539;", "category": "p", "order": "37"},
-		{"emoji": "😥", "name": "disappointed_relieved", "shortname": ":disappointed_relieved:", "unicode": "1f625", "html": "&#128549;", "category": "p", "order": "28"},
-		{"emoji": "😇", "name": "innocent", "shortname": ":innocent:", "unicode": "1f607", "html": "&#128519;", "category": "p", "order": "67"},
-		{"emoji": "🎧", "name": "headphones", "shortname": ":headphones:", "unicode": "1f3a7", "html": "&#127911;", "category": "a", "order": "1830"},
-		{"emoji": "✅", "name": "white_check_mark", "shortname": ":white_check_mark:", "unicode": "2705", "html": "&#9989;", "category": "s", "order": "2078"},
-		{"emoji": "😖", "name": "confounded", "shortname": ":confounded:", "unicode": "1f616", "html": "&#128534;", "category": "p", "order": "50"},
-		{"emoji": "➡", "name": "arrow_right", "shortname": ":arrow_right:", "unicode": "27a1", "html": "&#10145;", "category": "s", "order": "2004"},
-		{"emoji": "😠", "name": "angry", "shortname": ":angry:", "unicode": "1f620", "html": "&#128544;", "category": "p", "order": "66"},
-		{"emoji": "😬", "name": "grimacing", "shortname": ":grimacing:", "unicode": "1f62c", "html": "&#128556;", "category": "p", "order": "60"},
-		{"emoji": "🌟", "name": "star2", "shortname": ":star2:", "unicode": "1f31f", "html": "&#127775;", "category": "n", "order": "1728"},
-		{"emoji": "🔫", "name": "gun", "shortname": ":gun:", "unicode": "1f52b", "html": "&#128299;", "category": "o", "order": "1956"},
-		{"emoji": "🙋🏿‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&#127999;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙋🏾‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&#127998;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙋🏽‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&#127997;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙋🏼‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&#127996;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙋🏻‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&#127995;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙋‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙋🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&#127999;", "category": "", "order": ""},
-		{"emoji": "🙋🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&#127998;", "category": "", "order": ""},
-		{"emoji": "🙋🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&#127997;", "category": "", "order": ""},
-		{"emoji": "🙋🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&#127996;", "category": "", "order": ""},
-		{"emoji": "🙋🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128587;&#127995;", "category": "", "order": ""},
-		{"emoji": "🙋", "name": "raising_hand", "shortname": ":raising_hand:", "unicode": "1f64b", "html": "&#128587;", "category": "p", "order": "585"},
-		{"emoji": "👎🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128078;&#127999;", "category": "", "order": ""},
-		{"emoji": "👎🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128078;&#127998;", "category": "", "order": ""},
-		{"emoji": "👎🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128078;&#127997;", "category": "", "order": ""},
-		{"emoji": "👎🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128078;&#127996;", "category": "", "order": ""},
-		{"emoji": "👎🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128078;&#127995;", "category": "", "order": ""},
-		{"emoji": "👎", "name": "thumbsdown", "shortname": ":thumbsdown:", "unicode": "1f44e", "html": "&#128078;", "category": "p", "order": "1182"},
-		{"emoji": "💃🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128131;&#127999;", "category": "", "order": ""},
-		{"emoji": "💃🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128131;&#127998;", "category": "", "order": ""},
-		{"emoji": "💃🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128131;&#127997;", "category": "", "order": ""},
-		{"emoji": "💃🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128131;&#127996;", "category": "", "order": ""},
-		{"emoji": "💃🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128131;&#127995;", "category": "", "order": ""},
-		{"emoji": "💃", "name": "dancer", "shortname": ":dancer:", "unicode": "1f483", "html": "&#128131;", "category": "p", "order": "729"},
-		{"emoji": "🎵", "name": "musical_note", "shortname": ":musical_note:", "unicode": "1f3b5", "html": "&#127925;", "category": "s", "order": "1824"},
-		{"emoji": "😶", "name": "no_mouth", "shortname": ":no_mouth:", "unicode": "1f636", "html": "&#128566;", "category": "p", "order": "24"},
-		{"emoji": "💫", "name": "dizzy", "shortname": ":dizzy:", "unicode": "1f4ab", "html": "&#128171;", "category": "s", "order": "1308"},
-		{"emoji": "✊🏿", "name": "", "shortname": "", "unicode": "", "html": "&#9994;&#127999;", "category": "", "order": ""},
-		{"emoji": "✊🏾", "name": "", "shortname": "", "unicode": "", "html": "&#9994;&#127998;", "category": "", "order": ""},
-		{"emoji": "✊🏽", "name": "", "shortname": "", "unicode": "", "html": "&#9994;&#127997;", "category": "", "order": ""},
-		{"emoji": "✊🏼", "name": "", "shortname": "", "unicode": "", "html": "&#9994;&#127996;", "category": "", "order": ""},
-		{"emoji": "✊🏻", "name": "", "shortname": "", "unicode": "", "html": "&#9994;&#127995;", "category": "", "order": ""},
-		{"emoji": "✊", "name": "fist", "shortname": ":fist:", "unicode": "270a", "html": "&#9994;", "category": "p", "order": "1188"},
-		{"emoji": "👇🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128071;&#127999;", "category": "", "order": ""},
-		{"emoji": "👇🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128071;&#127998;", "category": "", "order": ""},
-		{"emoji": "👇🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128071;&#127997;", "category": "", "order": ""},
-		{"emoji": "👇🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128071;&#127996;", "category": "", "order": ""},
-		{"emoji": "👇🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128071;&#127995;", "category": "", "order": ""},
-		{"emoji": "👇", "name": "point_down", "shortname": ":point_down:", "unicode": "1f447", "html": "&#128071;", "category": "p", "order": "1122"},
-		{"emoji": "🔴", "name": "red_circle", "shortname": ":red_circle:", "unicode": "1f534", "html": "&#128308;", "category": "s", "order": "2179"},
-		{"emoji": "🙅🏿‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&#127999;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙅🏾‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&#127998;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙅🏽‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&#127997;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙅🏼‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&#127996;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙅🏻‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&#127995;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙅‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙅🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&#127999;", "category": "", "order": ""},
-		{"emoji": "🙅🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&#127998;", "category": "", "order": ""},
-		{"emoji": "🙅🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&#127997;", "category": "", "order": ""},
-		{"emoji": "🙅🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&#127996;", "category": "", "order": ""},
-		{"emoji": "🙅🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128581;&#127995;", "category": "", "order": ""},
-		{"emoji": "🙅", "name": "no_good", "shortname": ":no_good:", "unicode": "1f645", "html": "&#128581;", "category": "p", "order": "531"},
-		{"emoji": "💥", "name": "boom", "shortname": ":boom:", "unicode": "1f4a5", "html": "&#128165;", "category": "s", "order": "1305"},
-		{"emoji": "©️", "name": "", "shortname": "", "unicode": "", "html": "&copy;️", "category": "", "order": ""},
-		{"emoji": "💭", "name": "thought_balloon", "shortname": ":thought_balloon:", "unicode": "1f4ad", "html": "&#128173;", "category": "s", "order": "1312"},
-		{"emoji": "👅", "name": "tongue", "shortname": ":tongue:", "unicode": "1f445", "html": "&#128069;", "category": "p", "order": "1282"},
-		{"emoji": "💩", "name": "Pile of Poo", "shortname": ":poop:", "unicode": "1f4a9", "html": "&#128169;", "category": "p", "order": "85"},
-		{"emoji": "😰", "name": "cold_sweat", "shortname": ":cold_sweat:", "unicode": "1f630", "html": "&#128560;", "category": "p", "order": "61"},
-		{"emoji": "💎", "name": "gem", "shortname": ":gem:", "unicode": "1f48e", "html": "&#128142;", "category": "o", "order": "1341"},
-		{"emoji": "🙆🏿‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&#127999;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙆🏾‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&#127998;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙆🏽‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&#127997;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙆🏼‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&#127996;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙆🏻‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&#127995;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙆‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙆🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&#127999;", "category": "", "order": ""},
-		{"emoji": "🙆🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&#127998;", "category": "", "order": ""},
-		{"emoji": "🙆🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&#127997;", "category": "", "order": ""},
-		{"emoji": "🙆🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&#127996;", "category": "", "order": ""},
-		{"emoji": "🙆🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128582;&#127995;", "category": "", "order": ""},
-		{"emoji": "🙆", "name": "ok_woman", "shortname": ":ok_woman:", "unicode": "1f646", "html": "&#128582;", "category": "p", "order": "549"},
-		{"emoji": "🍕", "name": "pizza", "shortname": ":pizza:", "unicode": "1f355", "html": "&#127829;", "category": "d", "order": "1484"},
-		{"emoji": "😹", "name": "joy_cat", "shortname": ":joy_cat:", "unicode": "1f639", "html": "&#128569;", "category": "p", "order": "89"},
-		{"emoji": "🌞", "name": "sun_with_face", "shortname": ":sun_with_face:", "unicode": "1f31e", "html": "&#127774;", "category": "n", "order": "1726"},
-		{"emoji": "🍃", "name": "leaves", "shortname": ":leaves:", "unicode": "1f343", "html": "&#127811;", "category": "n", "order": "1448"},
-		{"emoji": "💦", "name": "sweat_drops", "shortname": ":sweat_drops:", "unicode": "1f4a6", "html": "&#128166;", "category": "n", "order": "1306"},
-		{"emoji": "🐧", "name": "penguin", "shortname": ":penguin:", "unicode": "1f427", "html": "&#128039;", "category": "n", "order": "1394"},
-		{"emoji": "💤", "name": "zzz", "shortname": ":zzz:", "unicode": "1f4a4", "html": "&#128164;", "category": "p", "order": "1302"},
-		{"emoji": "🚶🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚶🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚶🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚶🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚶🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚶‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚶🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&#127999;", "category": "", "order": ""},
-		{"emoji": "🚶🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&#127998;", "category": "", "order": ""},
-		{"emoji": "🚶🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&#127997;", "category": "", "order": ""},
-		{"emoji": "🚶🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&#127996;", "category": "", "order": ""},
-		{"emoji": "🚶🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128694;&#127995;", "category": "", "order": ""},
-		{"emoji": "🚶", "name": "walking", "shortname": ":walking:", "unicode": "1f6b6", "html": "&#128694;", "category": "p", "order": "693"},
-		{"emoji": "✈️", "name": "airplane", "shortname": ":airplane:", "unicode": "2708", "html": "&#9992;", "category": "t", "order": "1650"},
-		{"emoji": "🎈", "name": "balloon", "shortname": ":balloon:", "unicode": "1f388", "html": "&#127880;", "category": "o", "order": "1761"},
-		{"emoji": "⭐", "name": "star", "shortname": ":star:", "unicode": "2b50", "html": "&#11088;", "category": "n", "order": "1727"},
-		{"emoji": "🎀", "name": "ribbon", "shortname": ":ribbon:", "unicode": "1f380", "html": "&#127872;", "category": "o", "order": "1770"},
-		{"emoji": "☑️", "name": "ballot_box_with_check", "shortname": ":ballot_box_with_check:", "unicode": "2611", "html": "&#9745;", "category": "s", "order": "2079"},
-		{"emoji": "😟", "name": "worried", "shortname": ":worried:", "unicode": "1f61f", "html": "&#128543;", "category": "p", "order": "52"},
-		{"emoji": "🔞", "name": "underage", "shortname": ":underage:", "unicode": "1f51e", "html": "&#128286;", "category": "s", "order": "1999"},
-		{"emoji": "😨", "name": "fearful", "shortname": ":fearful:", "unicode": "1f628", "html": "&#128552;", "category": "p", "order": "58"},
-		{"emoji": "🍀", "name": "four_leaf_clover", "shortname": ":four_leaf_clover:", "unicode": "1f340", "html": "&#127808;", "category": "n", "order": "1445"},
-		{"emoji": "🌺", "name": "hibiscus", "shortname": ":hibiscus:", "unicode": "1f33a", "html": "&#127802;", "category": "n", "order": "1433"},
-		{"emoji": "🎤", "name": "microphone", "shortname": ":microphone:", "unicode": "1f3a4", "html": "&#127908;", "category": "a", "order": "1829"},
-		{"emoji": "👐🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128080;&#127999;", "category": "", "order": ""},
-		{"emoji": "👐🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128080;&#127998;", "category": "", "order": ""},
-		{"emoji": "👐🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128080;&#127997;", "category": "", "order": ""},
-		{"emoji": "👐🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128080;&#127996;", "category": "", "order": ""},
-		{"emoji": "👐🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128080;&#127995;", "category": "", "order": ""},
-		{"emoji": "👐", "name": "open_hands", "shortname": ":open_hands:", "unicode": "1f450", "html": "&#128080;", "category": "p", "order": "1236"},
-		{"emoji": "👻", "name": "ghost", "shortname": ":ghost:", "unicode": "1f47b", "html": "&#128123;", "category": "p", "order": "82"},
-		{"emoji": "🌴", "name": "palm_tree", "shortname": ":palm_tree:", "unicode": "1f334", "html": "&#127796;", "category": "n", "order": "1440"},
-		{"emoji": "‼️", "name": "bangbang", "shortname": ":bangbang:", "unicode": "203c", "html": "&#8252;", "category": "s", "order": "2096"},
-		{"emoji": "💅🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128133;&#127999;", "category": "", "order": ""},
-		{"emoji": "💅🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128133;&#127998;", "category": "", "order": ""},
-		{"emoji": "💅🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128133;&#127997;", "category": "", "order": ""},
-		{"emoji": "💅🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128133;&#127996;", "category": "", "order": ""},
-		{"emoji": "💅🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128133;&#127995;", "category": "", "order": ""},
-		{"emoji": "💅", "name": "nail_care", "shortname": ":nail_care:", "unicode": "1f485", "html": "&#128133;", "category": "p", "order": "1260"},
-		{"emoji": "❌", "name": "x", "shortname": ":x:", "unicode": "274c", "html": "&#10060;", "category": "s", "order": "2082"},
-		{"emoji": "👽", "name": "alien", "shortname": ":alien:", "unicode": "1f47d", "html": "&#128125;", "category": "p", "order": "83"},
-		{"emoji": "🙇🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🙇🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🙇🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🙇🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🙇🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🙇‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🙇🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&#127999;", "category": "", "order": ""},
-		{"emoji": "🙇🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&#127998;", "category": "", "order": ""},
-		{"emoji": "🙇🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&#127997;", "category": "", "order": ""},
-		{"emoji": "🙇🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&#127996;", "category": "", "order": ""},
-		{"emoji": "🙇🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128583;&#127995;", "category": "", "order": ""},
-		{"emoji": "🙇", "name": "bow", "shortname": ":bow:", "unicode": "1f647", "html": "&#128583;", "category": "p", "order": "603"},
-		{"emoji": "☁", "name": "cloud", "shortname": ":cloud:", "unicode": "2601", "html": "&#9729;", "category": "n", "order": "1730"},
-		{"emoji": "⚽", "name": "soccer", "shortname": ":soccer:", "unicode": "26bd", "html": "&#9917;", "category": "a", "order": "1781"},
-		{"emoji": "👼🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128124;&#127999;", "category": "", "order": ""},
-		{"emoji": "👼🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128124;&#127998;", "category": "", "order": ""},
-		{"emoji": "👼🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128124;&#127997;", "category": "", "order": ""},
-		{"emoji": "👼🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128124;&#127996;", "category": "", "order": ""},
-		{"emoji": "👼🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128124;&#127995;", "category": "", "order": ""},
-		{"emoji": "👼", "name": "angel", "shortname": ":angel:", "unicode": "1f47c", "html": "&#128124;", "category": "p", "order": "141"},
-		{"emoji": "👯‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128111;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "👯", "name": "dancers", "shortname": ":dancers:", "unicode": "1f46f", "html": "&#128111;", "category": "p", "order": "741"},
-		{"emoji": "❗", "name": "exclamation", "shortname": ":exclamation:", "unicode": "2757", "html": "&#10071;", "category": "s", "order": "2101"},
-		{"emoji": "❄️", "name": "snowflake", "shortname": ":snowflake:", "unicode": "2744", "html": "&#10052;", "category": "n", "order": "1749"},
-		{"emoji": "☝🏿", "name": "", "shortname": "", "unicode": "", "html": "&#9757;&#127999;", "category": "", "order": ""},
-		{"emoji": "☝🏾", "name": "", "shortname": "", "unicode": "", "html": "&#9757;&#127998;", "category": "", "order": ""},
-		{"emoji": "☝🏽", "name": "", "shortname": "", "unicode": "", "html": "&#9757;&#127997;", "category": "", "order": ""},
-		{"emoji": "☝🏼", "name": "", "shortname": "", "unicode": "", "html": "&#9757;&#127996;", "category": "", "order": ""},
-		{"emoji": "☝🏻", "name": "", "shortname": "", "unicode": "", "html": "&#9757;&#127995;", "category": "", "order": ""},
-		{"emoji": "☝️", "name": "point_up", "shortname": ":point_up:", "unicode": "261d", "html": "&#9757;", "category": "p", "order": "1104"},
-		{"emoji": "😙", "name": "kissing_smiling_eyes", "shortname": ":kissing_smiling_eyes:", "unicode": "1f619", "html": "&#128537;", "category": "p", "order": "16"},
-		{"emoji": "🌈", "name": "rainbow", "shortname": ":rainbow:", "unicode": "1f308", "html": "&#127752;", "category": "t", "order": "1743"},
-		{"emoji": "🌙", "name": "crescent_moon", "shortname": ":crescent_moon:", "unicode": "1f319", "html": "&#127769;", "category": "n", "order": "1719"},
-		{"emoji": "💟", "name": "heart_decoration", "shortname": ":heart_decoration:", "unicode": "1f49f", "html": "&#128159;", "category": "s", "order": "1299"},
-		{"emoji": "💝", "name": "gift_heart", "shortname": ":gift_heart:", "unicode": "1f49d", "html": "&#128157;", "category": "s", "order": "1297"},
-		{"emoji": "🎁", "name": "gift", "shortname": ":gift:", "unicode": "1f381", "html": "&#127873;", "category": "o", "order": "1771"},
-		{"emoji": "🍻", "name": "beers", "shortname": ":beers:", "unicode": "1f37b", "html": "&#127867;", "category": "d", "order": "1530"},
-		{"emoji": "😧", "name": "anguished", "shortname": ":anguished:", "unicode": "1f627", "html": "&#128551;", "category": "p", "order": "57"},
-		{"emoji": "🌍", "name": "earth_africa", "shortname": ":earth_africa:", "unicode": "1f30d", "html": "&#127757;", "category": "n", "order": "1538"},
-		{"emoji": "🎥", "name": "movie_camera", "shortname": ":movie_camera:", "unicode": "1f3a5", "html": "&#127909;", "category": "o", "order": "1856"},
-		{"emoji": "⚓", "name": "anchor", "shortname": ":anchor:", "unicode": "2693", "html": "&#9875;", "category": "t", "order": "1642"},
-		{"emoji": "⚡", "name": "zap", "shortname": ":zap:", "unicode": "26a1", "html": "&#9889;", "category": "n", "order": "1748"},
-		{"emoji": "♣️", "name": "", "shortname": "", "unicode": "", "html": "&clubs;️", "category": "", "order": ""},
-		{"emoji": "✖️", "name": "heavy_multiplication_x", "shortname": ":heavy_multiplication_x:", "unicode": "2716", "html": "&#10006;", "category": "s", "order": "2081"},
-		{"emoji": "🏃🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏃🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏃🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏃🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏃🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏃‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏃🏿", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&#127999;", "category": "", "order": ""},
-		{"emoji": "🏃🏾", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&#127998;", "category": "", "order": ""},
-		{"emoji": "🏃🏽", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&#127997;", "category": "", "order": ""},
-		{"emoji": "🏃🏼", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&#127996;", "category": "", "order": ""},
-		{"emoji": "🏃🏻", "name": "", "shortname": "", "unicode": "", "html": "&#127939;&#127995;", "category": "", "order": ""},
-		{"emoji": "🏃", "name": "runner", "shortname": ":runner:", "unicode": "1f3c3", "html": "&#127939;", "category": "p", "order": "711"},
-		{"emoji": "🌻", "name": "sunflower", "shortname": ":sunflower:", "unicode": "1f33b", "html": "&#127803;", "category": "n", "order": "1434"},
-		{"emoji": "🌎", "name": "earth_americas", "shortname": ":earth_americas:", "unicode": "1f30e", "html": "&#127758;", "category": "n", "order": "1539"},
-		{"emoji": "💐", "name": "bouquet", "shortname": ":bouquet:", "unicode": "1f490", "html": "&#128144;", "category": "n", "order": "1427"},
-		{"emoji": "🐶", "name": "dog", "shortname": ":dog:", "unicode": "1f436", "html": "&#128054;", "category": "n", "order": "1345"},
-		{"emoji": "💰", "name": "moneybag", "shortname": ":moneybag:", "unicode": "1f4b0", "html": "&#128176;", "category": "o", "order": "1891"},
-		{"emoji": "🌿", "name": "herb", "shortname": ":herb:", "unicode": "1f33f", "html": "&#127807;", "category": "n", "order": "1443"},
-		{"emoji": "👫", "name": "couple", "shortname": ":couple:", "unicode": "1f46b", "html": "&#128107;", "category": "p", "order": "1018"},
-		{"emoji": "🍂", "name": "fallen_leaf", "shortname": ":fallen_leaf:", "unicode": "1f342", "html": "&#127810;", "category": "n", "order": "1447"},
-		{"emoji": "🌷", "name": "tulip", "shortname": ":tulip:", "unicode": "1f337", "html": "&#127799;", "category": "n", "order": "1436"},
-		{"emoji": "🎂", "name": "birthday", "shortname": ":birthday:", "unicode": "1f382", "html": "&#127874;", "category": "d", "order": "1513"},
-		{"emoji": "🐱", "name": "cat", "shortname": ":cat:", "unicode": "1f431", "html": "&#128049;", "category": "n", "order": "1350"},
-		{"emoji": "☕", "name": "coffee", "shortname": ":coffee:", "unicode": "2615", "html": "&#9749;", "category": "d", "order": "1522"},
-		{"emoji": "😵", "name": "dizzy_face", "shortname": ":dizzy_face:", "unicode": "1f635", "html": "&#128565;", "category": "p", "order": "64"},
-		{"emoji": "👆🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128070;&#127999;", "category": "", "order": ""},
-		{"emoji": "👆🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128070;&#127998;", "category": "", "order": ""},
-		{"emoji": "👆🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128070;&#127997;", "category": "", "order": ""},
-		{"emoji": "👆🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128070;&#127996;", "category": "", "order": ""},
-		{"emoji": "👆🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128070;&#127995;", "category": "", "order": ""},
-		{"emoji": "👆", "name": "point_up_2", "shortname": ":point_up_2:", "unicode": "1f446", "html": "&#128070;", "category": "p", "order": "1110"},
-		{"emoji": "😮", "name": "open_mouth", "shortname": ":open_mouth:", "unicode": "1f62e", "html": "&#128558;", "category": "p", "order": "29"},
-		{"emoji": "😯", "name": "hushed", "shortname": ":hushed:", "unicode": "1f62f", "html": "&#128559;", "category": "p", "order": "31"},
-		{"emoji": "🏀", "name": "basketball", "shortname": ":basketball:", "unicode": "1f3c0", "html": "&#127936;", "category": "a", "order": "1783"},
-		{"emoji": "🎄", "name": "christmas_tree", "shortname": ":christmas_tree:", "unicode": "1f384", "html": "&#127876;", "category": "n", "order": "1757"},
-		{"emoji": "💍", "name": "ring", "shortname": ":ring:", "unicode": "1f48d", "html": "&#128141;", "category": "p", "order": "1340"},
-		{"emoji": "🌝", "name": "full_moon_with_face", "shortname": ":full_moon_with_face:", "unicode": "1f31d", "html": "&#127773;", "category": "n", "order": "1725"},
-		{"emoji": "😲", "name": "astonished", "shortname": ":astonished:", "unicode": "1f632", "html": "&#128562;", "category": "p", "order": "47"},
-		{"emoji": "👭", "name": "two_women_holding_hands", "shortname": ":two_women_holding_hands:", "unicode": "1f46d", "html": "&#128109;", "category": "p", "order": "1030"},
-		{"emoji": "💸", "name": "money_with_wings", "shortname": ":money_with_wings:", "unicode": "1f4b8", "html": "&#128184;", "category": "o", "order": "1896"},
-		{"emoji": "😿", "name": "crying_cat_face", "shortname": ":crying_cat_face:", "unicode": "1f63f", "html": "&#128575;", "category": "p", "order": "94"},
-		{"emoji": "🙉", "name": "hear_no_evil", "shortname": ":hear_no_evil:", "unicode": "1f649", "html": "&#128585;", "category": "n", "order": "97"},
-		{"emoji": "💨", "name": "dash", "shortname": ":dash:", "unicode": "1f4a8", "html": "&#128168;", "category": "n", "order": "1307"},
-		{"emoji": "🌵", "name": "cactus", "shortname": ":cactus:", "unicode": "1f335", "html": "&#127797;", "category": "n", "order": "1441"},
-		{"emoji": "♨️", "name": "hotsprings", "shortname": ":hotsprings:", "unicode": "2668", "html": "&#9832;", "category": "s", "order": "1591"},
-		{"emoji": "☎️", "name": "telephone", "shortname": ":telephone:", "unicode": "260e", "html": "&#9742;", "category": "o", "order": "1840"},
-		{"emoji": "🍁", "name": "maple_leaf", "shortname": ":maple_leaf:", "unicode": "1f341", "html": "&#127809;", "category": "n", "order": "1446"},
-		{"emoji": "👸🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128120;&#127999;", "category": "p", "order": ""},
-		{"emoji": "👸🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128120;&#127998;", "category": "p", "order": ""},
-		{"emoji": "👸🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128120;&#127997;", "category": "p", "order": ""},
-		{"emoji": "👸🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128120;&#127996;", "category": "p", "order": ""},
-		{"emoji": "👸🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128120;&#127995;", "category": "p", "order": ""},
-		{"emoji": "👸", "name": "princess", "shortname": ":princess:", "unicode": "1f478", "html": "&#128120;", "category": "p", "order": "459"},
-		{"emoji": "💆🏿‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&#127999;&zwj;&#9794;", "category": "p", "order": ""},
-		{"emoji": "💆🏾‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&#127998;&zwj;&#9794;", "category": "p", "order": ""},
-		{"emoji": "💆🏽‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&#127997;&zwj;&#9794;", "category": "p", "order": ""},
-		{"emoji": "💆🏼‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&#127996;&zwj;&#9794;", "category": "p", "order": ""},
-		{"emoji": "💆🏻‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&#127995;&zwj;&#9794;", "category": "p", "order": ""},
-		{"emoji": "💆‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&zwj;&#9794;", "category": "p", "order": ""},
-		{"emoji": "💆🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&#127999;", "category": "p", "order": ""},
-		{"emoji": "💆🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&#127998;", "category": "p", "order": ""},
-		{"emoji": "💆🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&#127997;", "category": "p", "order": ""},
-		{"emoji": "💆🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&#127996;", "category": "p", "order": ""},
-		{"emoji": "💆🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128134;&#127995;", "category": "p", "order": ""},
-		{"emoji": "💆", "name": "massage", "shortname": ":massage:", "unicode": "1f486", "html": "&#128134;", "category": "p", "order": "657"},
-		{"emoji": "💌", "name": "love_letter", "shortname": ":love_letter:", "unicode": "1f48c", "html": "&#128140;", "category": "o", "order": "1301"},
-		{"emoji": "🏆", "name": "trophy", "shortname": ":trophy:", "unicode": "1f3c6", "html": "&#127942;", "category": "a", "order": "1776"},
-		{"emoji": "🙍🏿‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&#127999;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙍🏾‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&#127998;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙍🏽‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&#127997;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙍🏼‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&#127996;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙍🏻‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&#127995;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙍‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙍🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&#127999;", "category": "", "order": ""},
-		{"emoji": "🙍🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&#127998;", "category": "", "order": ""},
-		{"emoji": "🙍🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&#127997;", "category": "", "order": ""},
-		{"emoji": "🙍🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&#127996;", "category": "", "order": ""},
-		{"emoji": "🙍🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128589;&#127995;", "category": "", "order": ""},
-		{"emoji": "🙍", "name": "person_frowning", "shortname": ":person_frowning:", "unicode": "1f64d", "html": "&#128589;", "category": "p", "order": "495"},
-		{"emoji": "🇺🇸", "name": "United States of America", "shortname": ":us:", "unicode": "1f1fa", "html": "&#127482;", "category": "f", "order": ""},
-		{"emoji": "🎊", "name": "confetti_ball", "shortname": ":confetti_ball:", "unicode": "1f38a", "html": "&#127882;", "category": "o", "order": "1763"},
-		{"emoji": "🌼", "name": "blossom", "shortname": ":blossom:", "unicode": "1f33c", "html": "&#127804;", "category": "n", "order": "1435"},
-		{"emoji": "🔪", "name": "", "shortname": "", "unicode": "", "html": "&#128298;", "category": "", "order": ""},
-		{"emoji": "👄", "name": "lips", "shortname": ":lips:", "unicode": "1f444", "html": "&#128068;", "category": "p", "order": "1283"},
-		{"emoji": "🍟", "name": "fries", "shortname": ":fries:", "unicode": "1f35f", "html": "&#127839;", "category": "d", "order": "1483"},
-		{"emoji": "🍩", "name": "doughnut", "shortname": ":doughnut:", "unicode": "1f369", "html": "&#127849;", "category": "d", "order": "1511"},
-		{"emoji": "😦", "name": "frowning", "shortname": ":frowning:", "unicode": "1f626", "html": "&#128550;", "category": "p", "order": "56"},
-		{"emoji": "🌊", "name": "ocean", "shortname": ":ocean:", "unicode": "1f30a", "html": "&#127754;", "category": "n", "order": "1755"},
-		{"emoji": "💣", "name": "bomb", "shortname": ":bomb:", "unicode": "1f4a3", "html": "&#128163;", "category": "o", "order": "1304"},
-		{"emoji": "🆗", "name": "ok", "shortname": ":ok:", "unicode": "1f197", "html": "&#127383;", "category": "s", "order": "2137"},
-		{"emoji": "🌀", "name": "cyclone", "shortname": ":cyclone:", "unicode": "1f300", "html": "&#127744;", "category": "s", "order": "1742"},
-		{"emoji": "🚀", "name": "rocket", "shortname": ":rocket:", "unicode": "1f680", "html": "&#128640;", "category": "t", "order": "1659"},
-		{"emoji": "☔", "name": "umbrella", "shortname": ":umbrella:", "unicode": "2614", "html": "&#9748;", "category": "n", "order": "1746"},
-		{"emoji": "💏", "name": "couplekiss", "shortname": ":couplekiss:", "unicode": "1f48f", "html": "&#128143;", "category": "p", "order": "1036"},
-		{"emoji": "👩‍❤️‍💋‍👩", "name": "couple_woman_kiss", "shortname": ":couple_woman_kiss:", "unicode": "", "html": "&#128105;&zwj;&#10084;&zwj;&#128139;&zwj;&#128105;", "category": "p", "order": ""},
-		{"emoji": "👨‍❤️‍💋‍👨", "name": "couple_man_kiss", "shortname": ":couple_man_kiss:", "unicode": "", "html": "&#128104;&zwj;&#10084;&zwj;&#128139;&zwj;&#128104;", "category": "p", "order": ""},
-		{"emoji": "💑", "name": "couple_with_heart", "shortname": ":couple_with_heart:", "unicode": "1f491", "html": "&#128145;", "category": "p", "order": "1040"},
-		{"emoji": "👩‍❤️‍👩", "name": "girl_girl_love", "shortname": "", "unicode": "", "html": "&#128105;&zwj;&#10084;&zwj;&#128105;", "category": "p", "order": ""},
-		{"emoji": "👨‍❤️‍👨", "name": "man_man_love", "shortname": ":man_man_love:", "unicode": "", "html": "&#128104;&zwj;&#10084;&zwj;&#128104;", "category": "p", "order": ""},
-		{"emoji": "🍭", "name": "lollipop", "shortname": ":lollipop:", "unicode": "1f36d", "html": "&#127853;", "category": "d", "order": "1517"},
-		{"emoji": "🎬", "name": "clapper", "shortname": ":clapper:", "unicode": "1f3ac", "html": "&#127916;", "category": "a", "order": "1859"},
-		{"emoji": "🐷", "name": "pig", "shortname": ":pig:", "unicode": "1f437", "html": "&#128055;", "category": "n", "order": "1364"},
-		{"emoji": "😈", "name": "smiling_imp", "shortname": ":smiling_imp:", "unicode": "1f608", "html": "&#128520;", "category": "p", "order": "76"},
-		{"emoji": "👿", "name": "imp", "shortname": ":imp:", "unicode": "1f47f", "html": "&#128127;", "category": "p", "order": "77"},
-		{"emoji": "🐝", "name": "bee", "shortname": ":bee:", "unicode": "1f41d", "html": "&#128029;", "category": "n", "order": "1422"},
-		{"emoji": "😽", "name": "kissing_cat", "shortname": ":kissing_cat:", "unicode": "1f63d", "html": "&#128573;", "category": "p", "order": "92"},
-		{"emoji": "💢", "name": "anger", "shortname": ":anger:", "unicode": "1f4a2", "html": "&#128162;", "category": "s", "order": "1303"},
-		{"emoji": "🎼", "name": "musical_score", "shortname": ":musical_score:", "unicode": "1f3bc", "html": "&#127932;", "category": "a", "order": "1823"},
-		{"emoji": "🎅🏿", "name": "", "shortname": "", "unicode": "", "html": "&#127877;&#127999;", "category": "", "order": ""},
-		{"emoji": "🎅🏾", "name": "", "shortname": "", "unicode": "", "html": "&#127877;&#127998;", "category": "", "order": ""},
-		{"emoji": "🎅🏽", "name": "", "shortname": "", "unicode": "", "html": "&#127877;&#127997;", "category": "", "order": ""},
-		{"emoji": "🎅🏼", "name": "", "shortname": "", "unicode": "", "html": "&#127877;&#127996;", "category": "", "order": ""},
-		{"emoji": "🎅🏻", "name": "", "shortname": "", "unicode": "", "html": "&#127877;&#127995;", "category": "", "order": ""},
-		{"emoji": "🎅", "name": "santa", "shortname": ":santa:", "unicode": "1f385", "html": "&#127877;", "category": "p", "order": "447"},
-		{"emoji": "🌏", "name": "earth_asia", "shortname": ":earth_asia:", "unicode": "1f30f", "html": "&#127759;", "category": "n", "order": "1540"},
-		{"emoji": "🏈", "name": "football", "shortname": ":football:", "unicode": "1f3c8", "html": "&#127944;", "category": "a", "order": "1785"},
-		{"emoji": "🎸", "name": "guitar", "shortname": ":guitar:", "unicode": "1f3b8", "html": "&#127928;", "category": "a", "order": "1833"},
-		{"emoji": "♦️", "name": "", "shortname": "", "unicode": "", "html": "&diams;️", "category": "", "order": ""},
-		{"emoji": "🐼", "name": "panda_face", "shortname": ":panda_face:", "unicode": "1f43c", "html": "&#128060;", "category": "n", "order": "1385"},
-		{"emoji": "💬", "name": "speech_balloon", "shortname": ":speech_balloon:", "unicode": "1f4ac", "html": "&#128172;", "category": "s", "order": "1309"},
-		{"emoji": "🍓", "name": "strawberry", "shortname": ":strawberry:", "unicode": "1f353", "html": "&#127827;", "category": "d", "order": "1461"},
-		{"emoji": "😼", "name": "smirk_cat", "shortname": ":smirk_cat:", "unicode": "1f63c", "html": "&#128572;", "category": "p", "order": "91"},
-		{"emoji": "🍌", "name": "banana", "shortname": ":banana:", "unicode": "1f34c", "html": "&#127820;", "category": "d", "order": "1454"},
-		{"emoji": "🍉", "name": "watermelon", "shortname": ":watermelon:", "unicode": "1f349", "html": "&#127817;", "category": "d", "order": "1451"},
-		{"emoji": "⛄", "name": "snowman", "shortname": ":snowman:", "unicode": "26c4", "html": "&#9924;", "category": "n", "order": "1751"},
-		{"emoji": "😸", "name": "smile_cat", "shortname": ":smile_cat:", "unicode": "1f638", "html": "&#128568;", "category": "p", "order": "88"},
-		{"emoji": "♠️", "name": "", "shortname": "", "unicode": "", "html": "&spades;️", "category": "", "order": ""},
-		{"emoji": "🔝", "name": "top", "shortname": ":top:", "unicode": "1f51d", "html": "&#128285;", "category": "s", "order": "2022"},
-		{"emoji": "🍆", "name": "eggplant", "shortname": ":eggplant:", "unicode": "1f346", "html": "&#127814;", "category": "d", "order": "1465"},
-		{"emoji": "🔮", "name": "crystal_ball", "shortname": ":crystal_ball:", "unicode": "1f52e", "html": "&#128302;", "category": "o", "order": "1974"},
-		{"emoji": "🍴", "name": "fork_and_knife", "shortname": ":fork_and_knife:", "unicode": "1f374", "html": "&#127860;", "category": "d", "order": "1534"},
-		{"emoji": "📲", "name": "calling", "shortname": ":calling:", "unicode": "1f4f2", "html": "&#128242;", "category": "o", "order": "1839"},
-		{"emoji": "📱", "name": "iphone", "shortname": ":iphone:", "unicode": "1f4f1", "html": "&#128241;", "category": "o", "order": "1838"},
-		{"emoji": "⛅", "name": "partly_sunny", "shortname": ":partly_sunny:", "unicode": "26c5", "html": "&#9925;", "category": "n", "order": "1731"},
-		{"emoji": "⚠️", "name": "warning", "shortname": ":warning:", "unicode": "26a0", "html": "&#9888;", "category": "s", "order": "1989"},
-		{"emoji": "🙀", "name": "scream_cat", "shortname": ":scream_cat:", "unicode": "1f640", "html": "&#128576;", "category": "p", "order": "93"},
-		{"emoji": "🔸", "name": "small_orange_diamond", "shortname": ":small_orange_diamond:", "unicode": "1f538", "html": "&#128312;", "category": "s", "order": "2169"},
-		{"emoji": "👶🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128118;&#127999;", "category": "", "order": ""},
-		{"emoji": "👶🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128118;&#127998;", "category": "", "order": ""},
-		{"emoji": "👶🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128118;&#127997;", "category": "", "order": ""},
-		{"emoji": "👶🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128118;&#127996;", "category": "", "order": ""},
-		{"emoji": "👶🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128118;&#127995;", "category": "", "order": ""},
-		{"emoji": "👶", "name": "baby", "shortname": ":baby:", "unicode": "1f476", "html": "&#128118;", "category": "p", "order": "135"},
-		{"emoji": "🐾", "name": "feet", "shortname": ":feet:", "unicode": "1f43e", "html": "&#128062;", "category": "n", "order": "1386"},
-		{"emoji": "👣", "name": "footprints", "shortname": ":footprints:", "unicode": "1f463", "html": "&#128099;", "category": "p", "order": "1278"},
-		{"emoji": "🍺", "name": "beer", "shortname": ":beer:", "unicode": "1f37a", "html": "&#127866;", "category": "d", "order": "1529"},
-		{"emoji": "🍷", "name": "wine_glass", "shortname": ":wine_glass:", "unicode": "1f377", "html": "&#127863;", "category": "d", "order": "1526"},
-		{"emoji": "⭕", "name": "o", "shortname": ":o:", "unicode": "2b55", "html": "&#11093;", "category": "s", "order": "2077"},
-		{"emoji": "📹", "name": "video_camera", "shortname": ":video_camera:", "unicode": "1f4f9", "html": "&#128249;", "category": "o", "order": "1863"},
-		{"emoji": "🐰", "name": "rabbit", "shortname": ":rabbit:", "unicode": "1f430", "html": "&#128048;", "category": "n", "order": "1379"},
-		{"emoji": "🍹", "name": "tropical_drink", "shortname": ":tropical_drink:", "unicode": "1f379", "html": "&#127865;", "category": "d", "order": "1528"},
-		{"emoji": "🚬", "name": "smoking", "shortname": ":smoking:", "unicode": "1f6ac", "html": "&#128684;", "category": "o", "order": "1969"},
-		{"emoji": "👾", "name": "space_invader", "shortname": ":space_invader:", "unicode": "1f47e", "html": "&#128126;", "category": "a", "order": "84"},
-		{"emoji": "🍑", "name": "peach", "shortname": ":peach:", "unicode": "1f351", "html": "&#127825;", "category": "d", "order": "1459"},
-		{"emoji": "🐍", "name": "snake", "shortname": ":snake:", "unicode": "1f40d", "html": "&#128013;", "category": "n", "order": "1403"},
-		{"emoji": "🐢", "name": "turtle", "shortname": ":turtle:", "unicode": "1f422", "html": "&#128034;", "category": "n", "order": "1401"},
-		{"emoji": "🍒", "name": "cherries", "shortname": ":cherries:", "unicode": "1f352", "html": "&#127826;", "category": "d", "order": "1460"},
-		{"emoji": "😗", "name": "kissing", "shortname": ":kissing:", "unicode": "1f617", "html": "&#128535;", "category": "p", "order": "15"},
-		{"emoji": "🐸", "name": "frog", "shortname": ":frog:", "unicode": "1f438", "html": "&#128056;", "category": "n", "order": "1399"},
-		{"emoji": "🌌", "name": "milky_way", "shortname": ":milky_way:", "unicode": "1f30c", "html": "&#127756;", "category": "t", "order": "1592"},
-		{"emoji": "🚨", "name": "rotating_light", "shortname": ":rotating_light:", "unicode": "1f6a8", "html": "&#128680;", "category": "t", "order": "1637"},
-		{"emoji": "🐣", "name": "hatching_chick", "shortname": ":hatching_chick:", "unicode": "1f423", "html": "&#128035;", "category": "n", "order": "1390"},
-		{"emoji": "📕", "name": "closed_book", "shortname": ":closed_book:", "unicode": "1f4d5", "html": "&#128213;", "category": "o", "order": "1875"},
-		{"emoji": "🍬", "name": "candy", "shortname": ":candy:", "unicode": "1f36c", "html": "&#127852;", "category": "d", "order": "1516"},
-		{"emoji": "🍔", "name": "hamburger", "shortname": ":hamburger:", "unicode": "1f354", "html": "&#127828;", "category": "d", "order": "1482"},
-		{"emoji": "🐻", "name": "bear", "shortname": ":bear:", "unicode": "1f43b", "html": "&#128059;", "category": "n", "order": "1383"},
-		{"emoji": "🐯", "name": "tiger", "shortname": ":tiger:", "unicode": "1f42f", "html": "&#128047;", "category": "n", "order": "1353"},
-		{"emoji": "🚗", "name": "", "shortname": "", "unicode": "", "html": "&#128663;", "category": "", "order": ""},
-		{"emoji": "⏩", "name": "fast_forward", "shortname": ":fast_forward:", "unicode": "2.3E+10", "html": "&#9193;", "category": "s", "order": "2052"},
-		{"emoji": "🍦", "name": "icecream", "shortname": ":icecream:", "unicode": "1f366", "html": "&#127846;", "category": "d", "order": "1508"},
-		{"emoji": "🍍", "name": "pineapple", "shortname": ":pineapple:", "unicode": "1f34d", "html": "&#127821;", "category": "d", "order": "1455"},
-		{"emoji": "🌾", "name": "ear_of_rice", "shortname": ":ear_of_rice:", "unicode": "1f33e", "html": "&#127806;", "category": "n", "order": "1442"},
-		{"emoji": "💉", "name": "syringe", "shortname": ":syringe:", "unicode": "1f489", "html": "&#128137;", "category": "o", "order": "1967"},
-		{"emoji": "🚮", "name": "put_litter_in_its_place", "shortname": ":put_litter_in_its_place:", "unicode": "1f6ae", "html": "&#128686;", "category": "s", "order": "1977"},
-		{"emoji": "🍫", "name": "chocolate_bar", "shortname": ":chocolate_bar:", "unicode": "1f36b", "html": "&#127851;", "category": "d", "order": "1515"},
-		{"emoji": "▪️", "name": "black_small_square", "shortname": ":black_small_square:", "unicode": "25aa", "html": "&#9642;", "category": "s", "order": "2159"},
-		{"emoji": "📺", "name": "tv", "shortname": ":tv:", "unicode": "1f4fa", "html": "&#128250;", "category": "o", "order": "1860"},
-		{"emoji": "💊", "name": "pill", "shortname": ":pill:", "unicode": "1f48a", "html": "&#128138;", "category": "o", "order": "1968"},
-		{"emoji": "🐙", "name": "octopus", "shortname": ":octopus:", "unicode": "1f419", "html": "&#128025;", "category": "n", "order": "1413"},
-		{"emoji": "🎃", "name": "jack_o_lantern", "shortname": ":jack_o_lantern:", "unicode": "1f383", "html": "&#127875;", "category": "n", "order": "1756"},
-		{"emoji": "🍇", "name": "grapes", "shortname": ":grapes:", "unicode": "1f347", "html": "&#127815;", "category": "d", "order": "1449"},
-		{"emoji": "😺", "name": "smiley_cat", "shortname": ":smiley_cat:", "unicode": "1f63a", "html": "&#128570;", "category": "p", "order": "87"},
-		{"emoji": "💿", "name": "cd", "shortname": ":cd:", "unicode": "1f4bf", "html": "&#128191;", "category": "o", "order": "1854"},
-		{"emoji": "🍸", "name": "cocktail", "shortname": ":cocktail:", "unicode": "1f378", "html": "&#127864;", "category": "d", "order": "1527"},
-		{"emoji": "🍰", "name": "cake", "shortname": ":cake:", "unicode": "1f370", "html": "&#127856;", "category": "d", "order": "1514"},
-		{"emoji": "🎮", "name": "video_game", "shortname": ":video_game:", "unicode": "1f3ae", "html": "&#127918;", "category": "a", "order": "1804"},
-		{"emoji": "™️", "name": "", "shortname": "", "unicode": "", "html": "&trade;️", "category": "", "order": ""},
-		{"emoji": "⬇️", "name": "arrow_down", "shortname": ":arrow_down:", "unicode": "2b07", "html": "&#11015;", "category": "s", "order": "2006"},
-		{"emoji": "🚫", "name": "no_entry_sign", "shortname": ":no_entry_sign:", "unicode": "1f6ab", "html": "&#128683;", "category": "s", "order": "1992"},
-		{"emoji": "💄", "name": "lipstick", "shortname": ":lipstick:", "unicode": "1f484", "html": "&#128132;", "category": "p", "order": "1339"},
-		{"emoji": "🐳", "name": "whale", "shortname": ":whale:", "unicode": "1f433", "html": "&#128051;", "category": "n", "order": "1406"},
-		{"emoji": "📝", "name": "", "shortname": "", "unicode": "", "html": "&#128221;", "category": "", "order": ""},
-		{"emoji": "®️", "name": "", "shortname": "", "unicode": "", "html": "&reg;️", "category": "", "order": ""},
-		{"emoji": "🍪", "name": "cookie", "shortname": ":cookie:", "unicode": "1f36a", "html": "&#127850;", "category": "d", "order": "1512"},
-		{"emoji": "🐬", "name": "dolphin", "shortname": ":dolphin:", "unicode": "1f42c", "html": "&#128044;", "category": "n", "order": "1408"},
-		{"emoji": "🔊", "name": "loud_sound", "shortname": ":loud_sound:", "unicode": "1f50a", "html": "&#128266;", "category": "s", "order": "1817"},
-		{"emoji": "👨🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128104;&#127999;", "category": "", "order": ""},
-		{"emoji": "👨🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128104;&#127998;", "category": "", "order": ""},
-		{"emoji": "👨🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128104;&#127997;", "category": "", "order": ""},
-		{"emoji": "👨🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128104;&#127996;", "category": "", "order": ""},
-		{"emoji": "👨🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128104;&#127995;", "category": "", "order": ""},
-		{"emoji": "👨", "name": "man", "shortname": ":man:", "unicode": "1f468", "html": "&#128104;", "category": "p", "order": "111"},
-		{"emoji": "🐥", "name": "hatched_chick", "shortname": ":hatched_chick:", "unicode": "1f425", "html": "&#128037;", "category": "n", "order": "1392"},
-		{"emoji": "🐒", "name": "monkey", "shortname": ":monkey:", "unicode": "1f412", "html": "&#128018;", "category": "n", "order": "1343"},
-		{"emoji": "📚", "name": "books", "shortname": ":books:", "unicode": "1f4da", "html": "&#128218;", "category": "o", "order": "1880"},
-		{"emoji": "👹", "name": "japanese_ogre", "shortname": ":japanese_ogre:", "unicode": "1f479", "html": "&#128121;", "category": "p", "order": "78"},
-		{"emoji": "💂🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "💂🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "💂🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "💂🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "💂🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "💂‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "💂🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&#127999;", "category": "", "order": ""},
-		{"emoji": "💂🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&#127998;", "category": "", "order": ""},
-		{"emoji": "💂🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&#127997;", "category": "", "order": ""},
-		{"emoji": "💂🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&#127996;", "category": "", "order": ""},
-		{"emoji": "💂🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128130;&#127995;", "category": "", "order": ""},
-		{"emoji": "💂", "name": "guardsman", "shortname": ":guardsman:", "unicode": "1f482", "html": "&#128130;", "category": "p", "order": "375"},
-		{"emoji": "📢", "name": "loudspeaker", "shortname": ":loudspeaker:", "unicode": "1f4e2", "html": "&#128226;", "category": "s", "order": "1818"},
-		{"emoji": "✂️", "name": "scissors", "shortname": ":scissors:", "unicode": "2702", "html": "&#9986;", "category": "o", "order": "1940"},
-		{"emoji": "👧🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128103;&#127999;", "category": "", "order": ""},
-		{"emoji": "👧🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128103;&#127998;", "category": "", "order": ""},
-		{"emoji": "👧🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128103;&#127997;", "category": "", "order": ""},
-		{"emoji": "👧🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128103;&#127996;", "category": "", "order": ""},
-		{"emoji": "👧🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128103;&#127995;", "category": "", "order": ""},
-		{"emoji": "👧", "name": "girl", "shortname": ":girl:", "unicode": "1f467", "html": "&#128103;", "category": "p", "order": "105"},
-		{"emoji": "🎓", "name": "mortar_board", "shortname": ":mortar_board:", "unicode": "1f393", "html": "&#127891;", "category": "p", "order": "1336"},
-		{"emoji": "🇫🇷", "name": "France", "shortname": ":fr:", "unicode": "1f1eb", "html": "&#127467;", "category": "f", "order": ""},
-		{"emoji": "⚾️", "name": "baseball", "shortname": ":baseball:", "unicode": "26be", "html": "&#9918;", "category": "a", "order": "1782"},
-		{"emoji": "🚦", "name": "vertical_traffic_light", "shortname": ":vertical_traffic_light:", "unicode": "1f6a6", "html": "&#128678;", "category": "t", "order": "1639"},
-		{"emoji": "👩🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128105;&#127999;", "category": "", "order": ""},
-		{"emoji": "👩🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128105;&#127998;", "category": "", "order": ""},
-		{"emoji": "👩🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128105;&#127997;", "category": "", "order": ""},
-		{"emoji": "👩🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128105;&#127996;", "category": "", "order": ""},
-		{"emoji": "👩🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128105;&#127995;", "category": "", "order": ""},
-		{"emoji": "👩", "name": "woman", "shortname": ":woman:", "unicode": "1f469", "html": "&#128105;", "category": "p", "order": "117"},
-		{"emoji": "🎆", "name": "fireworks", "shortname": ":fireworks:", "unicode": "1f386", "html": "&#127878;", "category": "t", "order": "1758"},
-		{"emoji": "🌠", "name": "stars", "shortname": ":stars:", "unicode": "1f320", "html": "&#127776;", "category": "t", "order": "1729"},
-		{"emoji": "🆘", "name": "sos", "shortname": ":sos:", "unicode": "1f198", "html": "&#127384;", "category": "s", "order": "2139"},
-		{"emoji": "🍄", "name": "mushroom", "shortname": ":mushroom:", "unicode": "1f344", "html": "&#127812;", "category": "n", "order": "1471"},
-		{"emoji": "😾", "name": "pouting_cat", "shortname": ":pouting_cat:", "unicode": "1f63e", "html": "&#128574;", "category": "p", "order": "95"},
-		{"emoji": "🛅", "name": "left_luggage", "shortname": ":left_luggage:", "unicode": "1f6c5", "html": "&#128709;", "category": "s", "order": "1988"},
-		{"emoji": "👠", "name": "high_heel", "shortname": ":high_heel:", "unicode": "1f460", "html": "&#128096;", "category": "p", "order": "1330"},
-		{"emoji": "🎯", "name": "dart", "shortname": ":dart:", "unicode": "1f3af", "html": "&#127919;", "category": "a", "order": "1798"},
-		{"emoji": "🏊🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏊🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏊🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏊🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏊🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏊‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏊🏿", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&#127999;", "category": "", "order": ""},
-		{"emoji": "🏊🏾", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&#127998;", "category": "", "order": ""},
-		{"emoji": "🏊🏽", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&#127997;", "category": "", "order": ""},
-		{"emoji": "🏊🏼", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&#127996;", "category": "", "order": ""},
-		{"emoji": "🏊🏻", "name": "", "shortname": "", "unicode": "", "html": "&#127946;&#127995;", "category": "", "order": ""},
-		{"emoji": "🏊", "name": "swimmer", "shortname": ":swimmer:", "unicode": "1f3ca", "html": "&#127946;", "category": "a", "order": "836"},
-		{"emoji": "🔑", "name": "key", "shortname": ":key:", "unicode": "1f511", "html": "&#128273;", "category": "o", "order": "1948"},
-		{"emoji": "👙", "name": "bikini", "shortname": ":bikini:", "unicode": "1f459", "html": "&#128089;", "category": "p", "order": "1321"},
-		{"emoji": "👪", "name": "family", "shortname": ":family:", "unicode": "1f46a", "html": "&#128106;", "category": "p", "order": "1044"},
-		{"emoji": "✏", "name": "pencil2", "shortname": ":pencil2:", "unicode": "270f", "html": "&#9999;", "category": "o", "order": "1914"},
-		{"emoji": "🐘", "name": "elephant", "shortname": ":elephant:", "unicode": "1f418", "html": "&#128024;", "category": "n", "order": "1373"},
-		{"emoji": "💧", "name": "droplet", "shortname": ":droplet:", "unicode": "1f4a7", "html": "&#128167;", "category": "n", "order": "1754"},
-		{"emoji": "🌱", "name": "seedling", "shortname": ":seedling:", "unicode": "1f331", "html": "&#127793;", "category": "n", "order": "1437"},
-		{"emoji": "🍎", "name": "apple", "shortname": ":apple:", "unicode": "1f34e", "html": "&#127822;", "category": "d", "order": "1456"},
-		{"emoji": "🆒", "name": "cool", "shortname": ":cool:", "unicode": "1f192", "html": "&#127378;", "category": "s", "order": "2129"},
-		{"emoji": "📞", "name": "telephone_receiver", "shortname": ":telephone_receiver:", "unicode": "1f4de", "html": "&#128222;", "category": "o", "order": "1841"},
-		{"emoji": "💵", "name": "dollar", "shortname": ":dollar:", "unicode": "1f4b5", "html": "&#128181;", "category": "o", "order": "1893"},
-		{"emoji": "🏡", "name": "house_with_garden", "shortname": ":house_with_garden:", "unicode": "1f3e1", "html": "&#127969;", "category": "t", "order": "1560"},
-		{"emoji": "📖", "name": "book", "shortname": ":book:", "unicode": "1f4d6", "html": "&#128214;", "category": "o", "order": "1876"},
-		{"emoji": "💇🏿‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&#127999;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💇🏾‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&#127998;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💇🏽‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&#127997;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💇🏼‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&#127996;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💇🏻‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&#127995;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💇‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "💇🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&#127999;", "category": "", "order": ""},
-		{"emoji": "💇🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&#127998;", "category": "", "order": ""},
-		{"emoji": "💇🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&#127997;", "category": "", "order": ""},
-		{"emoji": "💇🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&#127996;", "category": "", "order": ""},
-		{"emoji": "💇🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128135;&#127995;", "category": "", "order": ""},
-		{"emoji": "💇", "name": "haircut", "shortname": ":haircut:", "unicode": "1f487", "html": "&#128135;", "category": "p", "order": "675"},
-		{"emoji": "💻", "name": "computer", "shortname": ":computer:", "unicode": "1f4bb", "html": "&#128187;", "category": "o", "order": "1846"},
-		{"emoji": "💡", "name": "bulb", "shortname": ":bulb:", "unicode": "1f4a1", "html": "&#128161;", "category": "o", "order": "1871"},
-		{"emoji": "❓", "name": "question", "shortname": ":question:", "unicode": "2753", "html": "&#10067;", "category": "s", "order": "2098"},
-		{"emoji": "🔙", "name": "back", "shortname": ":back:", "unicode": "1f519", "html": "&#128281;", "category": "s", "order": "2018"},
-		{"emoji": "👦🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128102;&#127999;", "category": "", "order": ""},
-		{"emoji": "👦🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128102;&#127998;", "category": "", "order": ""},
-		{"emoji": "👦🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128102;&#127997;", "category": "", "order": ""},
-		{"emoji": "👦🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128102;&#127996;", "category": "", "order": ""},
-		{"emoji": "👦🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128102;&#127995;", "category": "", "order": ""},
-		{"emoji": "👦", "name": "boy", "shortname": ":boy:", "unicode": "1f466", "html": "&#128102;", "category": "p", "order": "99"},
-		{"emoji": "🔐", "name": "closed_lock_with_key", "shortname": ":closed_lock_with_key:", "unicode": "1f510", "html": "&#128272;", "category": "o", "order": "1947"},
-		{"emoji": "🙎🏿‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&#127999;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙎🏾‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&#127998;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙎🏽‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&#127997;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙎🏼‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&#127996;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙎🏻‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&#127995;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙎‍♂", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&zwj;&#9794;", "category": "", "order": ""},
-		{"emoji": "🙎🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&#127999;", "category": "", "order": ""},
-		{"emoji": "🙎🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&#127998;", "category": "", "order": ""},
-		{"emoji": "🙎🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&#127997;", "category": "", "order": ""},
-		{"emoji": "🙎🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&#127996;", "category": "", "order": ""},
-		{"emoji": "🙎🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128590;&#127995;", "category": "", "order": ""},
-		{"emoji": "🙎", "name": "person_with_pouting_face", "shortname": ":person_with_pouting_face:", "unicode": "1f64e", "html": "&#128590;", "category": "p", "order": "513"},
-		{"emoji": "🍊", "name": "tangerine", "shortname": ":tangerine:", "unicode": "1f34a", "html": "&#127818;", "category": "d", "order": "1452"},
-		{"emoji": "↔️", "name": "", "shortname": "", "unicode": "", "html": "&harr;️", "category": "", "order": ""},
-		{"emoji": "🌅", "name": "sunrise", "shortname": ":sunrise:", "unicode": "1f305", "html": "&#127749;", "category": "t", "order": "1587"},
-		{"emoji": "🍗", "name": "poultry_leg", "shortname": ":poultry_leg:", "unicode": "1f357", "html": "&#127831;", "category": "d", "order": "1480"},
-		{"emoji": "🔵", "name": "blue_circle", "shortname": ":blue_circle:", "unicode": "1f535", "html": "&#128309;", "category": "s", "order": "2180"},
-		{"emoji": "🚘", "name": "oncoming_automobile", "shortname": ":oncoming_automobile:", "unicode": "1f698", "html": "&#128664;", "category": "t", "order": "1625"},
-		{"emoji": "🍧", "name": "shaved_ice", "shortname": ":shaved_ice:", "unicode": "1f367", "html": "&#127847;", "category": "d", "order": "1509"},
-		{"emoji": "🇮🇹", "name": "Italy", "shortname": ":it:", "unicode": "", "html": "&#127470;", "category": "f", "order": ""},
-		{"emoji": "🐦", "name": "bird", "shortname": ":bird:", "unicode": "1f426", "html": "&#128038;", "category": "n", "order": "1393"},
-		{"emoji": "🇬🇧", "name": "Great Britain", "shortname": ":gb:", "unicode": "", "html": "&#127468;", "category": "f", "order": ""},
-		{"emoji": "🌛", "name": "first_quarter_moon_with_face", "shortname": ":first_quarter_moon_with_face:", "unicode": "1f31b", "html": "&#127771;", "category": "n", "order": "1721"},
-		{"emoji": "👓", "name": "eyeglasses", "shortname": ":eyeglasses:", "unicode": "1f453", "html": "&#128083;", "category": "p", "order": "1314"},
-		{"emoji": "🐐", "name": "goat", "shortname": ":goat:", "unicode": "1f410", "html": "&#128016;", "category": "n", "order": "1370"},
-		{"emoji": "🌃", "name": "night_with_stars", "shortname": ":night_with_stars:", "unicode": "1f303", "html": "&#127747;", "category": "t", "order": "1585"},
-		{"emoji": "👵🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128117;&#127999;", "category": "", "order": ""},
-		{"emoji": "👵🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128117;&#127998;", "category": "", "order": ""},
-		{"emoji": "👵🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128117;&#127997;", "category": "", "order": ""},
-		{"emoji": "👵🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128117;&#127996;", "category": "", "order": ""},
-		{"emoji": "👵🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128117;&#127995;", "category": "", "order": ""},
-		{"emoji": "👵", "name": "older_woman", "shortname": ":older_woman:", "unicode": "1f475", "html": "&#128117;", "category": "p", "order": "129"},
-		{"emoji": "⚫", "name": "black_circle", "shortname": ":black_circle:", "unicode": "26ab", "html": "&#9899;", "category": "s", "order": "2178"},
-		{"emoji": "🌑", "name": "new_moon", "shortname": ":new_moon:", "unicode": "1f311", "html": "&#127761;", "category": "n", "order": "1711"},
-		{"emoji": "👬", "name": "two_men_holding_hands", "shortname": ":two_men_holding_hands:", "unicode": "1f46c", "html": "&#128108;", "category": "p", "order": "1024"},
-		{"emoji": "⚪", "name": "white_circle", "shortname": ":white_circle:", "unicode": "26aa", "html": "&#9898;", "category": "s", "order": "2177"},
-		{"emoji": "🛃", "name": "customs", "shortname": ":customs:", "unicode": "1f6c3", "html": "&#128707;", "category": "s", "order": "1986"},
-		{"emoji": "🐠", "name": "tropical_fish", "shortname": ":tropical_fish:", "unicode": "1f420", "html": "&#128032;", "category": "n", "order": "1410"},
-		{"emoji": "🏠", "name": "house", "shortname": ":house:", "unicode": "1f3e0", "html": "&#127968;", "category": "t", "order": "1559"},
-		{"emoji": "🔃", "name": "arrows_clockwise", "shortname": ":arrows_clockwise:", "unicode": "1f503", "html": "&#128259;", "category": "s", "order": "2016"},
-		{"emoji": "🌜", "name": "last_quarter_moon_with_face", "shortname": ":last_quarter_moon_with_face:", "unicode": "1f31c", "html": "&#127772;", "category": "n", "order": "1722"},
-		{"emoji": "📍", "name": "round_pushpin", "shortname": ":round_pushpin:", "unicode": "1f4cd", "html": "&#128205;", "category": "o", "order": "1935"},
-		{"emoji": "🌕", "name": "full_moon", "shortname": ":full_moon:", "unicode": "1f315", "html": "&#127765;", "category": "n", "order": "1715"},
-		{"emoji": "👟", "name": "athletic_shoe", "shortname": ":athletic_shoe:", "unicode": "1f45f", "html": "&#128095;", "category": "p", "order": "1329"},
-		{"emoji": "🍋", "name": "lemon", "shortname": ":lemon:", "unicode": "1f34b", "html": "&#127819;", "category": "d", "order": "1453"},
-		{"emoji": "🍼", "name": "baby_bottle", "shortname": ":baby_bottle:", "unicode": "1f37c", "html": "&#127868;", "category": "d", "order": "1520"},
-		{"emoji": "🎨", "name": "", "shortname": "", "unicode": "", "html": "&#127912;", "category": "", "order": ""},
-		{"emoji": "✉️", "name": "", "shortname": "", "unicode": "", "html": "&#9993;", "category": "", "order": ""},
-		{"emoji": "🍝", "name": "spaghetti", "shortname": ":spaghetti:", "unicode": "1f35d", "html": "&#127837;", "category": "d", "order": "1501"},
-		{"emoji": "🎐", "name": "wind_chime", "shortname": ":wind_chime:", "unicode": "1f390", "html": "&#127888;", "category": "o", "order": "1768"},
-		{"emoji": "🍥", "name": "fish_cake", "shortname": ":fish_cake:", "unicode": "1f365", "html": "&#127845;", "category": "d", "order": "1506"},
-		{"emoji": "🌲", "name": "evergreen_tree", "shortname": ":evergreen_tree:", "unicode": "1f332", "html": "&#127794;", "category": "n", "order": "1438"},
-		{"emoji": "🆙", "name": "up", "shortname": ":up:", "unicode": "1f199", "html": "&#127385;", "category": "s", "order": "2140"},
-		{"emoji": "⬆️", "name": "arrow_up", "shortname": ":arrow_up:", "unicode": "2b06", "html": "&#11014;", "category": "s", "order": "2002"},
-		{"emoji": "↗️", "name": "arrow_upper_right", "shortname": ":arrow_upper_right:", "unicode": "2197", "html": "&#8599;", "category": "s", "order": "2003"},
-		{"emoji": "↘️", "name": "arrow_lower_right", "shortname": ":arrow_lower_right:", "unicode": "2198", "html": "&#8600;", "category": "s", "order": "2005"},
-		{"emoji": "↙️", "name": "arrow_lower_left", "shortname": ":arrow_lower_left:", "unicode": "2199", "html": "&#8601;", "category": "s", "order": "2007"},
-		{"emoji": "🎭", "name": "performing_arts", "shortname": ":performing_arts:", "unicode": "1f3ad", "html": "&#127917;", "category": "a", "order": "1598"},
-		{"emoji": "👃🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128067;&#127999;", "category": "", "order": ""},
-		{"emoji": "👃🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128067;&#127998;", "category": "", "order": ""},
-		{"emoji": "👃🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128067;&#127997;", "category": "", "order": ""},
-		{"emoji": "👃🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128067;&#127996;", "category": "", "order": ""},
-		{"emoji": "👃🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128067;&#127995;", "category": "", "order": ""},
-		{"emoji": "👃", "name": "nose", "shortname": ":nose:", "unicode": "1f443", "html": "&#128067;", "category": "p", "order": "1272"},
-		{"emoji": "🐽", "name": "pig_nose", "shortname": ":pig_nose:", "unicode": "1f43d", "html": "&#128061;", "category": "n", "order": "1367"},
-		{"emoji": "🐟", "name": "fish", "shortname": ":fish:", "unicode": "1f41f", "html": "&#128031;", "category": "n", "order": "1409"},
-		{"emoji": "👳🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👳🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👳🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👳🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👳🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👳‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👳🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&#127999;", "category": "", "order": ""},
-		{"emoji": "👳🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&#127998;", "category": "", "order": ""},
-		{"emoji": "👳🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&#127997;", "category": "", "order": ""},
-		{"emoji": "👳🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&#127996;", "category": "", "order": ""},
-		{"emoji": "👳🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128115;&#127995;", "category": "", "order": ""},
-		{"emoji": "👳", "name": "man_with_turban", "shortname": ":man_with_turban:", "unicode": "1f473", "html": "&#128115;", "category": "p", "order": "411"},
-		{"emoji": "🐨", "name": "koala", "shortname": ":koala:", "unicode": "1f428", "html": "&#128040;", "category": "n", "order": "1384"},
-		{"emoji": "👂🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128066;&#127999;", "category": "", "order": ""},
-		{"emoji": "👂🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128066;&#127998;", "category": "", "order": ""},
-		{"emoji": "👂🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128066;&#127997;", "category": "", "order": ""},
-		{"emoji": "👂🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128066;&#127996;", "category": "", "order": ""},
-		{"emoji": "👂🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128066;&#127995;", "category": "", "order": ""},
-		{"emoji": "👂", "name": "ear", "shortname": ":ear:", "unicode": "1f442", "html": "&#128066;", "category": "p", "order": "1266"},
-		{"emoji": "✳️", "name": "eight_spoked_asterisk", "shortname": ":eight_spoked_asterisk:", "unicode": "2733", "html": "&#10035;", "category": "s", "order": "2093"},
-		{"emoji": "🔹", "name": "small_blue_diamond", "shortname": ":small_blue_diamond:", "unicode": "1f539", "html": "&#128313;", "category": "s", "order": "2170"},
-		{"emoji": "🚿", "name": "shower", "shortname": ":shower:", "unicode": "1f6bf", "html": "&#128703;", "category": "o", "order": "1672"},
-		{"emoji": "🐛", "name": "bug", "shortname": ":bug:", "unicode": "1f41b", "html": "&#128027;", "category": "n", "order": "1420"},
-		{"emoji": "🍜", "name": "ramen", "shortname": ":ramen:", "unicode": "1f35c", "html": "&#127836;", "category": "d", "order": "1500"},
-		{"emoji": "🎩", "name": "tophat", "shortname": ":tophat:", "unicode": "1f3a9", "html": "&#127913;", "category": "p", "order": "1335"},
-		{"emoji": "👰🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128112;&#127999;", "category": "", "order": ""},
-		{"emoji": "👰🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128112;&#127998;", "category": "", "order": ""},
-		{"emoji": "👰🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128112;&#127997;", "category": "", "order": ""},
-		{"emoji": "👰🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128112;&#127996;", "category": "", "order": ""},
-		{"emoji": "👰🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128112;&#127995;", "category": "", "order": ""},
-		{"emoji": "👰", "name": "bride_with_veil", "shortname": ":bride_with_veil:", "unicode": "1f470", "html": "&#128112;", "category": "p", "order": "471"},
-		{"emoji": "⛽", "name": "fuelpump", "shortname": ":fuelpump:", "unicode": "26fd", "html": "&#9981;", "category": "t", "order": "1636"},
-		{"emoji": "🏁", "name": "checkered_flag", "shortname": ":checkered_flag:", "unicode": "1f3c1", "html": "&#127937;", "category": "t", "order": "2181"},
-		{"emoji": "🐴", "name": "horse", "shortname": ":horse:", "unicode": "1f434", "html": "&#128052;", "category": "n", "order": "1356"},
-		{"emoji": "⌚", "name": "watch", "shortname": ":watch:", "unicode": "231a", "html": "&#8986;", "category": "o", "order": "1682"},
-		{"emoji": "🐵", "name": "monkey_face", "shortname": ":monkey_face:", "unicode": "1f435", "html": "&#128053;", "category": "n", "order": "1342"},
-		{"emoji": "🚼", "name": "baby_symbol", "shortname": ":baby_symbol:", "unicode": "1f6bc", "html": "&#128700;", "category": "s", "order": "1983"},
-		{"emoji": "🆕", "name": "new", "shortname": ":new:", "unicode": "1f195", "html": "&#127381;", "category": "s", "order": "2134"},
-		{"emoji": "🆓", "name": "free", "shortname": ":free:", "unicode": "1f193", "html": "&#127379;", "category": "s", "order": "2130"},
-		{"emoji": "🎇", "name": "sparkler", "shortname": ":sparkler:", "unicode": "1f387", "html": "&#127879;", "category": "t", "order": "1759"},
-		{"emoji": "🌽", "name": "corn", "shortname": ":corn:", "unicode": "1f33d", "html": "&#127805;", "category": "d", "order": "1468"},
-		{"emoji": "🎾", "name": "tennis", "shortname": ":tennis:", "unicode": "1f3be", "html": "&#127934;", "category": "a", "order": "1787"},
-		{"emoji": "⏰", "name": "alarm_clock", "shortname": ":alarm_clock:", "unicode": "23f0", "html": "&#9200;", "category": "o", "order": "1683"},
-		{"emoji": "🔋", "name": "battery", "shortname": ":battery:", "unicode": "1f50b", "html": "&#128267;", "category": "o", "order": "1844"},
-		{"emoji": "❕", "name": "grey_exclamation", "shortname": ":grey_exclamation:", "unicode": "2755", "html": "&#10069;", "category": "s", "order": "2100"},
-		{"emoji": "🐺", "name": "wolf", "shortname": ":wolf:", "unicode": "1f43a", "html": "&#128058;", "category": "n", "order": "1348"},
-		{"emoji": "🗿", "name": "moyai", "shortname": ":moyai:", "unicode": "1f5ff", "html": "&#128511;", "category": "o", "order": "1972"},
-		{"emoji": "🐮", "name": "cow", "shortname": ":cow:", "unicode": "1f42e", "html": "&#128046;", "category": "n", "order": "1360"},
-		{"emoji": "📣", "name": "mega", "shortname": ":mega:", "unicode": "1f4e3", "html": "&#128227;", "category": "s", "order": "1819"},
-		{"emoji": "👴🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128116;&#127999;", "category": "", "order": ""},
-		{"emoji": "👴🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128116;&#127998;", "category": "", "order": ""},
-		{"emoji": "👴🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128116;&#127997;", "category": "", "order": ""},
-		{"emoji": "👴🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128116;&#127996;", "category": "", "order": ""},
-		{"emoji": "👴🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128116;&#127995;", "category": "", "order": ""},
-		{"emoji": "👴", "name": "older_man", "shortname": ":older_man:", "unicode": "1f474", "html": "&#128116;", "category": "p", "order": "123"},
-		{"emoji": "👗", "name": "dress", "shortname": ":dress:", "unicode": "1f457", "html": "&#128087;", "category": "p", "order": "1319"},
-		{"emoji": "🔗", "name": "link", "shortname": ":link:", "unicode": "1f517", "html": "&#128279;", "category": "o", "order": "1965"},
-		{"emoji": "🐔", "name": "chicken", "shortname": ":chicken:", "unicode": "1f414", "html": "&#128020;", "category": "n", "order": "1388"},
-		{"emoji": "🍳", "name": "", "shortname": "", "unicode": "", "html": "&#127859;", "category": "", "order": ""},
-		{"emoji": "🐋", "name": "whale2", "shortname": ":whale2:", "unicode": "1f40b", "html": "&#128011;", "category": "n", "order": "1407"},
-		{"emoji": "↖", "name": "arrow_upper_left", "shortname": ":arrow_upper_left:", "unicode": "2196", "html": "&#8598;", "category": "s", "order": "2009"},
-		{"emoji": "🌳", "name": "deciduous_tree", "shortname": ":deciduous_tree:", "unicode": "1f333", "html": "&#127795;", "category": "n", "order": "1439"},
-		{"emoji": "🍱", "name": "bento", "shortname": ":bento:", "unicode": "1f371", "html": "&#127857;", "category": "d", "order": "1495"},
-		{"emoji": "📌", "name": "pushpin", "shortname": ":pushpin:", "unicode": "1f4cc", "html": "&#128204;", "category": "o", "order": "1934"},
-		{"emoji": "🔜", "name": "soon", "shortname": ":soon:", "unicode": "1f51c", "html": "&#128284;", "category": "s", "order": "2021"},
-		{"emoji": "🔁", "name": "repeat", "shortname": ":repeat:", "unicode": "1f501", "html": "&#128257;", "category": "s", "order": "2049"},
-		{"emoji": "🐉", "name": "dragon", "shortname": ":dragon:", "unicode": "1f409", "html": "&#128009;", "category": "n", "order": "1405"},
-		{"emoji": "🐹", "name": "hamster", "shortname": ":hamster:", "unicode": "1f439", "html": "&#128057;", "category": "n", "order": "1378"},
-		{"emoji": "⛳", "name": "golf", "shortname": ":golf:", "unicode": "26f3", "html": "&#9971;", "category": "a", "order": "1799"},
-		{"emoji": "🏄🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏄🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏄🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏄🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏄🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏄‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🏄🏿", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&#127999;", "category": "", "order": ""},
-		{"emoji": "🏄🏾", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&#127998;", "category": "", "order": ""},
-		{"emoji": "🏄🏽", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&#127997;", "category": "", "order": ""},
-		{"emoji": "🏄🏼", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&#127996;", "category": "", "order": ""},
-		{"emoji": "🏄🏻", "name": "", "shortname": "", "unicode": "", "html": "&#127940;&#127995;", "category": "", "order": ""},
-		{"emoji": "🏄", "name": "surfer", "shortname": ":surfer:", "unicode": "1f3c4", "html": "&#127940;", "category": "a", "order": "800"},
-		{"emoji": "🐭", "name": "mouse", "shortname": ":mouse:", "unicode": "1f42d", "html": "&#128045;", "category": "n", "order": "1375"},
-		{"emoji": "🌒", "name": "waxing_crescent_moon", "shortname": ":waxing_crescent_moon:", "unicode": "1f312", "html": "&#127762;", "category": "n", "order": "1712"},
-		{"emoji": "🚙", "name": "blue_car", "shortname": ":blue_car:", "unicode": "1f699", "html": "&#128665;", "category": "t", "order": "1626"},
-		{"emoji": "🅰️", "name": "a", "shortname": ":a:", "unicode": "1f170", "html": "&#127344;", "category": "s", "order": "2125"},
-		{"emoji": "⁉️", "name": "interrobang", "shortname": ":interrobang:", "unicode": "2049", "html": "&#8265;", "category": "s", "order": "2097"},
-		{"emoji": "🈹", "name": "u5272", "shortname": ":u5272:", "unicode": "1f239", "html": "&#127545;", "category": "s", "order": "2148"},
-		{"emoji": "🔌", "name": "electric_plug", "shortname": ":electric_plug:", "unicode": "1f50c", "html": "&#128268;", "category": "o", "order": "1845"},
-		{"emoji": "🌓", "name": "first_quarter_moon", "shortname": ":first_quarter_moon:", "unicode": "1f313", "html": "&#127763;", "category": "n", "order": "1713"},
-		{"emoji": "♋", "name": "cancer", "shortname": ":cancer:", "unicode": "264b", "html": "&#9803;", "category": "s", "order": "2038"},
-		{"emoji": "🔱", "name": "trident", "shortname": ":trident:", "unicode": "1f531", "html": "&#128305;", "category": "s", "order": "2076"},
-		{"emoji": "🍞", "name": "bread", "shortname": ":bread:", "unicode": "1f35e", "html": "&#127838;", "category": "d", "order": "1474"},
-		{"emoji": "👮🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👮🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👮🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👮🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👮🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👮‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👮🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&#127999;", "category": "", "order": ""},
-		{"emoji": "👮🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&#127998;", "category": "", "order": ""},
-		{"emoji": "👮🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&#127997;", "category": "", "order": ""},
-		{"emoji": "👮🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&#127996;", "category": "", "order": ""},
-		{"emoji": "👮🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128110;&#127995;", "category": "", "order": ""},
-		{"emoji": "👮", "name": "cop", "shortname": ":cop:", "unicode": "1f46e", "html": "&#128110;", "category": "p", "order": "339"},
-		{"emoji": "🍵", "name": "tea", "shortname": ":tea:", "unicode": "1f375", "html": "&#127861;", "category": "d", "order": "1523"},
-		{"emoji": "🎣", "name": "fishing_pole_and_fish", "shortname": ":fishing_pole_and_fish:", "unicode": "1f3a3", "html": "&#127907;", "category": "a", "order": "1801"},
-		{"emoji": "🌔", "name": "", "shortname": "", "unicode": "", "html": "&#127764;", "category": "", "order": ""},
-		{"emoji": "🚲", "name": "bike", "shortname": ":bike:", "unicode": "1f6b2", "html": "&#128690;", "category": "t", "order": "1630"},
-		{"emoji": "👤", "name": "", "shortname": "", "unicode": "", "html": "&#128100;", "category": "", "order": ""},
-		{"emoji": "🍚", "name": "rice", "shortname": ":rice:", "unicode": "1f35a", "html": "&#127834;", "category": "d", "order": "1498"},
-		{"emoji": "📻", "name": "radio", "shortname": ":radio:", "unicode": "1f4fb", "html": "&#128251;", "category": "o", "order": "1831"},
-		{"emoji": "🐤", "name": "baby_chick", "shortname": ":baby_chick:", "unicode": "1f424", "html": "&#128036;", "category": "n", "order": "1391"},
-		{"emoji": "⤵️", "name": "arrow_heading_down", "shortname": ":arrow_heading_down:", "unicode": "2935", "html": "&#10549;", "category": "s", "order": "2015"},
-		{"emoji": "🌘", "name": "waning_crescent_moon", "shortname": ":waning_crescent_moon:", "unicode": "1f318", "html": "&#127768;", "category": "n", "order": "1718"},
-		{"emoji": "↕", "name": "arrow_up_down", "shortname": ":arrow_up_down:", "unicode": "2195", "html": "&#8597;", "category": "s", "order": "2010"},
-		{"emoji": "🇪", "name": "", "shortname": "", "unicode": "", "html": "&#127466;", "category": "", "order": ""},
-		{"emoji": "🌗", "name": "last_quarter_moon", "shortname": ":last_quarter_moon:", "unicode": "1f317", "html": "&#127767;", "category": "n", "order": "1717"},
-		{"emoji": "🔘", "name": "radio_button", "shortname": ":radio_button:", "unicode": "1f518", "html": "&#128280;", "category": "s", "order": "2174"},
-		{"emoji": "🐑", "name": "sheep", "shortname": ":sheep:", "unicode": "1f411", "html": "&#128017;", "category": "n", "order": "1369"},
-		{"emoji": "👱🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👱🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👱🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👱🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👱🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👱‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👱🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&#127999;", "category": "", "order": ""},
-		{"emoji": "👱🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&#127998;", "category": "", "order": ""},
-		{"emoji": "👱🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&#127997;", "category": "", "order": ""},
-		{"emoji": "👱🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&#127996;", "category": "", "order": ""},
-		{"emoji": "👱🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128113;&#127995;", "category": "", "order": ""},
-		{"emoji": "👱", "name": "person_with_blond_hair", "shortname": ":person_with_blond_hair:", "unicode": "1f471", "html": "&#128113;", "category": "p", "order": "429"},
-		{"emoji": "🌖", "name": "waning_gibbous_moon", "shortname": ":waning_gibbous_moon:", "unicode": "1f316", "html": "&#127766;", "category": "n", "order": "1716"},
-		{"emoji": "🔒", "name": "lock", "shortname": ":lock:", "unicode": "1f512", "html": "&#128274;", "category": "o", "order": "1944"},
-		{"emoji": "🍏", "name": "green_apple", "shortname": ":green_apple:", "unicode": "1f34f", "html": "&#127823;", "category": "d", "order": "1457"},
-		{"emoji": "👺", "name": "japanese_goblin", "shortname": ":japanese_goblin:", "unicode": "1f47a", "html": "&#128122;", "category": "p", "order": "79"},
-		{"emoji": "➰", "name": "curly_loop", "shortname": ":curly_loop:", "unicode": "27b0", "html": "&#10160;", "category": "s", "order": "2090"},
-		{"emoji": "🚩", "name": "triangular_flag_on_post", "shortname": ":triangular_flag_on_post:", "unicode": "1f6a9", "html": "&#128681;", "category": "o", "order": "2182"},
-		{"emoji": "🔄", "name": "arrows_counterclockwise", "shortname": ":arrows_counterclockwise:", "unicode": "1f504", "html": "&#128260;", "category": "s", "order": "2017"},
-		{"emoji": "🐎", "name": "racehorse", "shortname": ":racehorse:", "unicode": "1f40e", "html": "&#128014;", "category": "n", "order": "1357"},
-		{"emoji": "🍤", "name": "fried_shrimp", "shortname": ":fried_shrimp:", "unicode": "1f364", "html": "&#127844;", "category": "d", "order": "1505"},
-		{"emoji": "🌄", "name": "sunrise_over_mountains", "shortname": ":sunrise_over_mountains:", "unicode": "1f304", "html": "&#127748;", "category": "t", "order": "1586"},
-		{"emoji": "🌋", "name": "volcano", "shortname": ":volcano:", "unicode": "1f30b", "html": "&#127755;", "category": "t", "order": "1546"},
-		{"emoji": "🐓", "name": "rooster", "shortname": ":rooster:", "unicode": "1f413", "html": "&#128019;", "category": "n", "order": "1389"},
-		{"emoji": "📥", "name": "inbox_tray", "shortname": ":inbox_tray:", "unicode": "1f4e5", "html": "&#128229;", "category": "o", "order": "1906"},
-		{"emoji": "💒", "name": "wedding", "shortname": ":wedding:", "unicode": "1f492", "html": "&#128146;", "category": "t", "order": "1574"},
-		{"emoji": "🍣", "name": "sushi", "shortname": ":sushi:", "unicode": "1f363", "html": "&#127843;", "category": "d", "order": "1504"},
-		{"emoji": "〰", "name": "wavy_dash", "shortname": ":wavy_dash:", "unicode": "3030", "html": "&#12336;", "category": "s", "order": "2102"},
-		{"emoji": "🍨", "name": "ice_cream", "shortname": ":ice_cream:", "unicode": "1f368", "html": "&#127848;", "category": "d", "order": "1510"},
-		{"emoji": "⏪", "name": "rewind", "shortname": ":rewind:", "unicode": "23ea", "html": "&#9194;", "category": "s", "order": "2056"},
-		{"emoji": "🍅", "name": "tomato", "shortname": ":tomato:", "unicode": "1f345", "html": "&#127813;", "category": "d", "order": "1463"},
-		{"emoji": "🐇", "name": "rabbit2", "shortname": ":rabbit2:", "unicode": "1f407", "html": "&#128007;", "category": "n", "order": "1380"},
-		{"emoji": "✴️", "name": "eight_pointed_black_star", "shortname": ":eight_pointed_black_star:", "unicode": "2734", "html": "&#10036;", "category": "s", "order": "2094"},
-		{"emoji": "🔺", "name": "small_red_triangle", "shortname": ":small_red_triangle:", "unicode": "1f53a", "html": "&#128314;", "category": "s", "order": "2171"},
-		{"emoji": "🔆", "name": "high_brightness", "shortname": ":high_brightness:", "unicode": "1f506", "html": "&#128262;", "category": "s", "order": "2068"},
-		{"emoji": "➕", "name": "heavy_plus_sign", "shortname": ":heavy_plus_sign:", "unicode": "2795", "html": "&#10133;", "category": "s", "order": "2084"},
-		{"emoji": "👲🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128114;&#127999;", "category": "", "order": ""},
-		{"emoji": "👲🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128114;&#127998;", "category": "", "order": ""},
-		{"emoji": "👲🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128114;&#127997;", "category": "", "order": ""},
-		{"emoji": "👲🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128114;&#127996;", "category": "", "order": ""},
-		{"emoji": "👲🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128114;&#127995;", "category": "", "order": ""},
-		{"emoji": "👲", "name": "man_with_gua_pi_mao", "shortname": ":man_with_gua_pi_mao:", "unicode": "1f472", "html": "&#128114;", "category": "p", "order": "489"},
-		{"emoji": "🏪", "name": "convenience_store", "shortname": ":convenience_store:", "unicode": "1f3ea", "html": "&#127978;", "category": "t", "order": "1568"},
-		{"emoji": "👥", "name": "busts_in_silhouette", "shortname": ":busts_in_silhouette:", "unicode": "1f465", "html": "&#128101;", "category": "p", "order": "767"},
-		{"emoji": "🐞", "name": "beetle", "shortname": ":beetle:", "unicode": "1f41e", "html": "&#128030;", "category": "n", "order": "1423"},
-		{"emoji": "🔻", "name": "small_red_triangle_down", "shortname": ":small_red_triangle_down:", "unicode": "1f53b", "html": "&#128315;", "category": "s", "order": "2172"},
-		{"emoji": "🇩🇪", "name": "Germany", "shortname": ":ger:", "unicode": "", "html": "&#127465;", "category": "", "order": ""},
-		{"emoji": "⤴️", "name": "arrow_heading_up", "shortname": ":arrow_heading_up:", "unicode": "2934", "html": "&#10548;", "category": "s", "order": "2014"},
-		{"emoji": "📛", "name": "name_badge", "shortname": ":name_badge:", "unicode": "1f4db", "html": "&#128219;", "category": "s", "order": "2073"},
-		{"emoji": "🛀🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128704;&#127999;", "category": "", "order": ""},
-		{"emoji": "🛀🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128704;&#127998;", "category": "", "order": ""},
-		{"emoji": "🛀🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128704;&#127997;", "category": "", "order": ""},
-		{"emoji": "🛀🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128704;&#127996;", "category": "", "order": ""},
-		{"emoji": "🛀🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128704;&#127995;", "category": "", "order": ""},
-		{"emoji": "🛀", "name": "bath", "shortname": ":bath:", "unicode": "1f6c0", "html": "&#128704;", "category": "a", "order": "1673"},
-		{"emoji": "⛔", "name": "no_entry", "shortname": ":no_entry:", "unicode": "26d4", "html": "&#9940;", "category": "s", "order": "1991"},
-		{"emoji": "🐊", "name": "crocodile", "shortname": ":crocodile:", "unicode": "1f40a", "html": "&#128010;", "category": "n", "order": "1400"},
-		{"emoji": "🌰", "name": "", "shortname": "", "unicode": "", "html": "&#127792;", "category": "", "order": ""},
-		{"emoji": "🐕", "name": "dog2", "shortname": ":dog2:", "unicode": "1f415", "html": "&#128021;", "category": "n", "order": "1346"},
-		{"emoji": "🐈", "name": "cat2", "shortname": ":cat2:", "unicode": "1f408", "html": "&#128008;", "category": "n", "order": "1351"},
-		{"emoji": "🔨", "name": "hammer", "shortname": ":hammer:", "unicode": "1f528", "html": "&#128296;", "category": "o", "order": "1950"},
-		{"emoji": "🍖", "name": "meat_on_bone", "shortname": ":meat_on_bone:", "unicode": "1f356", "html": "&#127830;", "category": "d", "order": "1479"},
-		{"emoji": "🐚", "name": "shell", "shortname": ":shell:", "unicode": "1f41a", "html": "&#128026;", "category": "n", "order": "1414"},
-		{"emoji": "❇️", "name": "sparkle", "shortname": ":sparkle:", "unicode": "2747", "html": "&#10055;", "category": "s", "order": "2095"},
-		{"emoji": "⛵", "name": "", "shortname": "", "unicode": "", "html": "&#9973;", "category": "", "order": ""},
-		{"emoji": "🅱️", "name": "b", "shortname": ":b:", "unicode": "1f171", "html": "&#127345;", "category": "s", "order": "2127"},
-		{"emoji": "Ⓜ️", "name": "m", "shortname": ":m:", "unicode": "24c2", "html": "&#9410;", "category": "s", "order": "2133"},
-		{"emoji": "🐩", "name": "poodle", "shortname": ":poodle:", "unicode": "1f429", "html": "&#128041;", "category": "n", "order": "1347"},
-		{"emoji": "♒", "name": "aquarius", "shortname": ":aquarius:", "unicode": "2652", "html": "&#9810;", "category": "s", "order": "2045"},
-		{"emoji": "🍲", "name": "stew", "shortname": ":stew:", "unicode": "1f372", "html": "&#127858;", "category": "d", "order": "1492"},
-		{"emoji": "👖", "name": "jeans", "shortname": ":jeans:", "unicode": "1f456", "html": "&#128086;", "category": "p", "order": "1318"},
-		{"emoji": "🍯", "name": "honey_pot", "shortname": ":honey_pot:", "unicode": "1f36f", "html": "&#127855;", "category": "d", "order": "1519"},
-		{"emoji": "🎹", "name": "musical_keyboard", "shortname": ":musical_keyboard:", "unicode": "1f3b9", "html": "&#127929;", "category": "a", "order": "1834"},
-		{"emoji": "🔓", "name": "unlock", "shortname": ":unlock:", "unicode": "1f513", "html": "&#128275;", "category": "o", "order": "1945"},
-		{"emoji": "✒", "name": "black_nib", "shortname": ":black_nib:", "unicode": "2712", "html": "&#10002;", "category": "o", "order": "1915"},
-		{"emoji": "🗽", "name": "statue_of_liberty", "shortname": ":statue_of_liberty:", "unicode": "1f5fd", "html": "&#128509;", "category": "t", "order": "1576"},
-		{"emoji": "💲", "name": "heavy_dollar_sign", "shortname": ":heavy_dollar_sign:", "unicode": "1f4b2", "html": "&#128178;", "category": "s", "order": "1900"},
-		{"emoji": "🏂", "name": "snowboarder", "shortname": ":snowboarder:", "unicode": "1f3c2", "html": "&#127938;", "category": "a", "order": "776"},
-		{"emoji": "💮", "name": "white_flower", "shortname": ":white_flower:", "unicode": "1f4ae", "html": "&#128174;", "category": "s", "order": "1429"},
-		{"emoji": "👔", "name": "necktie", "shortname": ":necktie:", "unicode": "1f454", "html": "&#128084;", "category": "p", "order": "1316"},
-		{"emoji": "💠", "name": "diamond_shape_with_a_dot_inside", "shortname": ":diamond_shape_with_a_dot_inside:", "unicode": "1f4a0", "html": "&#128160;", "category": "s", "order": "2173"},
-		{"emoji": "♈", "name": "aries", "shortname": ":aries:", "unicode": "2648", "html": "&#9800;", "category": "s", "order": "2035"},
-		{"emoji": "🚺", "name": "womens", "shortname": ":womens:", "unicode": "1f6ba", "html": "&#128698;", "category": "s", "order": "1981"},
-		{"emoji": "🐜", "name": "ant", "shortname": ":ant:", "unicode": "1f41c", "html": "&#128028;", "category": "n", "order": "1421"},
-		{"emoji": "♏", "name": "scorpius", "shortname": ":scorpius:", "unicode": "264f", "html": "&#9807;", "category": "s", "order": "2042"},
-		{"emoji": "🌇", "name": "city_sunset", "shortname": ":city_sunset:", "unicode": "1f307", "html": "&#127751;", "category": "t", "order": "1589"},
-		{"emoji": "⏳", "name": "hourglass_flowing_sand", "shortname": ":hourglass_flowing_sand:", "unicode": "23f3", "html": "&#9203;", "category": "o", "order": "1681"},
-		{"emoji": "🅾️", "name": "o2", "shortname": ":o2:", "unicode": "1f17e", "html": "&#127358;", "category": "s", "order": "2136"},
-		{"emoji": "🐲", "name": "dragon_face", "shortname": ":dragon_face:", "unicode": "1f432", "html": "&#128050;", "category": "n", "order": "1404"},
-		{"emoji": "🐌", "name": "snail", "shortname": ":snail:", "unicode": "1f40c", "html": "&#128012;", "category": "n", "order": "1419"},
-		{"emoji": "📀", "name": "dvd", "shortname": ":dvd:", "unicode": "1f4c0", "html": "&#128192;", "category": "o", "order": "1855"},
-		{"emoji": "👕", "name": "shirt", "shortname": ":shirt:", "unicode": "1f455", "html": "&#128085;", "category": "p", "order": "1317"},
-		{"emoji": "🎲", "name": "game_die", "shortname": ":game_die:", "unicode": "1f3b2", "html": "&#127922;", "category": "a", "order": "1806"},
-		{"emoji": "➖", "name": "heavy_minus_sign", "shortname": ":heavy_minus_sign:", "unicode": "2796", "html": "&#10134;", "category": "s", "order": "2088"},
-		{"emoji": "🎎", "name": "dolls", "shortname": ":dolls:", "unicode": "1f38e", "html": "&#127886;", "category": "o", "order": "1766"},
-		{"emoji": "♐", "name": "sagittarius", "shortname": ":sagittarius:", "unicode": "2650", "html": "&#9808;", "category": "s", "order": "2043"},
-		{"emoji": "🎱", "name": "8ball", "shortname": ":8ball:", "unicode": "1f3b1", "html": "&#127921;", "category": "a", "order": "1788"},
-		{"emoji": "🚌", "name": "bus", "shortname": ":bus:", "unicode": "1f68c", "html": "&#128652;", "category": "t", "order": "1614"},
-		{"emoji": "🍮", "name": "custard", "shortname": ":custard:", "unicode": "1f36e", "html": "&#127854;", "category": "d", "order": "1518"},
-		{"emoji": "🎌", "name": "crossed_flags", "shortname": ":crossed_flags:", "unicode": "1f38c", "html": "&#127884;", "category": "o", "order": "2183"},
-		{"emoji": "〽️", "name": "part_alternation_mark", "shortname": ":part_alternation_mark:", "unicode": "303d", "html": "&#12349;", "category": "s", "order": "2092"},
-		{"emoji": "🐫", "name": "camel", "shortname": ":camel:", "unicode": "1f42b", "html": "&#128043;", "category": "n", "order": "1372"},
-		{"emoji": "🍛", "name": "curry", "shortname": ":curry:", "unicode": "1f35b", "html": "&#127835;", "category": "d", "order": "1499"},
-		{"emoji": "🚂", "name": "steam_locomotive", "shortname": ":steam_locomotive:", "unicode": "1f682", "html": "&#128642;", "category": "t", "order": "1602"},
-		{"emoji": "🏥", "name": "hospital", "shortname": ":hospital:", "unicode": "1f3e5", "html": "&#127973;", "category": "t", "order": "1564"},
-		{"emoji": "🇯🇵", "name": "Japan", "shortname": ":jp:", "unicode": "", "html": "&#127471;", "category": "", "order": ""},
-		{"emoji": "🔷", "name": "large_blue_diamond", "shortname": ":large_blue_diamond:", "unicode": "1f537", "html": "&#128311;", "category": "s", "order": "2168"},
-		{"emoji": "🎋", "name": "tanabata_tree", "shortname": ":tanabata_tree:", "unicode": "1f38b", "html": "&#127883;", "category": "n", "order": "1764"},
-		{"emoji": "🔔", "name": "bell", "shortname": ":bell:", "unicode": "1f514", "html": "&#128276;", "category": "s", "order": "1821"},
-		{"emoji": "♌", "name": "leo", "shortname": ":leo:", "unicode": "264c", "html": "&#9804;", "category": "s", "order": "2039"},
-		{"emoji": "♊", "name": "gemini", "shortname": ":gemini:", "unicode": "264a", "html": "&#9802;", "category": "s", "order": "2037"},
-		{"emoji": "🍐", "name": "pear", "shortname": ":pear:", "unicode": "1f350", "html": "&#127824;", "category": "d", "order": "1458"},
-		{"emoji": "🔶", "name": "large_orange_diamond", "shortname": ":large_orange_diamond:", "unicode": "1f536", "html": "&#128310;", "category": "s", "order": "2167"},
-		{"emoji": "♉", "name": "taurus", "shortname": ":taurus:", "unicode": "2649", "html": "&#9801;", "category": "s", "order": "2036"},
-		{"emoji": "🌐", "name": "globe_with_meridians", "shortname": ":globe_with_meridians:", "unicode": "1f310", "html": "&#127760;", "category": "s", "order": "1541"},
-		{"emoji": "🚪", "name": "door", "shortname": ":door:", "unicode": "1f6aa", "html": "&#128682;", "category": "o", "order": "1662"},
-		{"emoji": "🕕", "name": "clock6", "shortname": ":clock6:", "unicode": "1f555", "html": "&#128341;", "category": "s", "order": "1699"},
-		{"emoji": "🚔", "name": "oncoming_police_car", "shortname": ":oncoming_police_car:", "unicode": "1f694", "html": "&#128660;", "category": "t", "order": "1621"},
-		{"emoji": "📩", "name": "envelope_with_arrow", "shortname": ":envelope_with_arrow:", "unicode": "1f4e9", "html": "&#128233;", "category": "o", "order": "1904"},
-		{"emoji": "🌂", "name": "closed_umbrella", "shortname": ":closed_umbrella:", "unicode": "1f302", "html": "&#127746;", "category": "p", "order": "1744"},
-		{"emoji": "🎷", "name": "saxophone", "shortname": ":saxophone:", "unicode": "1f3b7", "html": "&#127927;", "category": "a", "order": "1832"},
-		{"emoji": "⛪", "name": "church", "shortname": ":church:", "unicode": "26ea", "html": "&#9962;", "category": "t", "order": "1577"},
-		{"emoji": "🚴🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚴🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚴🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚴🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚴🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚴‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚴🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&#127999;", "category": "", "order": ""},
-		{"emoji": "🚴🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&#127998;", "category": "", "order": ""},
-		{"emoji": "🚴🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&#127997;", "category": "", "order": ""},
-		{"emoji": "🚴🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&#127996;", "category": "", "order": ""},
-		{"emoji": "🚴🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128692;&#127995;", "category": "", "order": ""},
-		{"emoji": "🚴", "name": "bicyclist", "shortname": ":bicyclist:", "unicode": "1f6b4", "html": "&#128692;", "category": "a", "order": "890"},
-		{"emoji": "♓", "name": "pisces", "shortname": ":pisces:", "unicode": "2653", "html": "&#9811;", "category": "s", "order": "2046"},
-		{"emoji": "🍡", "name": "dango", "shortname": ":dango:", "unicode": "1f361", "html": "&#127841;", "category": "d", "order": "1507"},
-		{"emoji": "♑", "name": "capricorn", "shortname": ":capricorn:", "unicode": "2651", "html": "&#9809;", "category": "s", "order": "2044"},
-		{"emoji": "🏢", "name": "office", "shortname": ":office:", "unicode": "1f3e2", "html": "&#127970;", "category": "t", "order": "1561"},
-		{"emoji": "🚣🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚣🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚣🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚣🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚣🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚣‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚣🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&#127999;", "category": "", "order": ""},
-		{"emoji": "🚣🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&#127998;", "category": "", "order": ""},
-		{"emoji": "🚣🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&#127997;", "category": "", "order": ""},
-		{"emoji": "🚣🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&#127996;", "category": "", "order": ""},
-		{"emoji": "🚣🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128675;&#127995;", "category": "", "order": ""},
-		{"emoji": "🚣", "name": "rowboat", "shortname": ":rowboat:", "unicode": "1f6a3", "html": "&#128675;", "category": "a", "order": "818"},
-		{"emoji": "👒", "name": "womans_hat", "shortname": ":womans_hat:", "unicode": "1f452", "html": "&#128082;", "category": "p", "order": "1334"},
-		{"emoji": "👞", "name": "mans_shoe", "shortname": ":mans_shoe:", "unicode": "1f45e", "html": "&#128094;", "category": "p", "order": "1328"},
-		{"emoji": "🏩", "name": "love_hotel", "shortname": ":love_hotel:", "unicode": "1f3e9", "html": "&#127977;", "category": "t", "order": "1567"},
-		{"emoji": "🗻", "name": "mount_fuji", "shortname": ":mount_fuji:", "unicode": "1f5fb", "html": "&#128507;", "category": "t", "order": "1547"},
-		{"emoji": "🐪", "name": "dromedary_camel", "shortname": ":dromedary_camel:", "unicode": "1f42a", "html": "&#128042;", "category": "n", "order": "1371"},
-		{"emoji": "👜", "name": "handbag", "shortname": ":handbag:", "unicode": "1f45c", "html": "&#128092;", "category": "p", "order": "1324"},
-		{"emoji": "⌛", "name": "hourglass", "shortname": ":hourglass:", "unicode": "231b", "html": "&#8987;", "category": "o", "order": "1680"},
-		{"emoji": "❎", "name": "negative_squared_cross_mark", "shortname": ":negative_squared_cross_mark:", "unicode": "274e", "html": "&#10062;", "category": "s", "order": "2083"},
-		{"emoji": "🎺", "name": "trumpet", "shortname": ":trumpet:", "unicode": "1f3ba", "html": "&#127930;", "category": "a", "order": "1835"},
-		{"emoji": "🏫", "name": "school", "shortname": ":school:", "unicode": "1f3eb", "html": "&#127979;", "category": "t", "order": "1569"},
-		{"emoji": "🐄", "name": "cow2", "shortname": ":cow2:", "unicode": "1f404", "html": "&#128004;", "category": "n", "order": "1363"},
-		{"emoji": "🌆", "name": "", "shortname": "", "unicode": "", "html": "&#127750;", "category": "", "order": ""},
-		{"emoji": "👷🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👷🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👷🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👷🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👷🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👷‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "👷🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&#127999;", "category": "", "order": ""},
-		{"emoji": "👷🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&#127998;", "category": "", "order": ""},
-		{"emoji": "👷🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&#127997;", "category": "", "order": ""},
-		{"emoji": "👷🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&#127996;", "category": "", "order": ""},
-		{"emoji": "👷🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128119;&#127995;", "category": "", "order": ""},
-		{"emoji": "👷", "name": "construction_worker", "shortname": ":construction_worker:", "unicode": "1f477", "html": "&#128119;", "category": "p", "order": "393"},
-		{"emoji": "🚽", "name": "toilet", "shortname": ":toilet:", "unicode": "1f6bd", "html": "&#128701;", "category": "o", "order": "1671"},
-		{"emoji": "🐖", "name": "pig2", "shortname": ":pig2:", "unicode": "1f416", "html": "&#128022;", "category": "n", "order": "1365"},
-		{"emoji": "❔", "name": "grey_question", "shortname": ":grey_question:", "unicode": "2754", "html": "&#10068;", "category": "s", "order": "2099"},
-		{"emoji": "🔰", "name": "beginner", "shortname": ":beginner:", "unicode": "1f530", "html": "&#128304;", "category": "s", "order": "2075"},
-		{"emoji": "🎻", "name": "violin", "shortname": ":violin:", "unicode": "1f3bb", "html": "&#127931;", "category": "a", "order": "1836"},
-		{"emoji": "🔛", "name": "on", "shortname": ":on:", "unicode": "1f51b", "html": "&#128283;", "category": "s", "order": "2020"},
-		{"emoji": "💳", "name": "credit_card", "shortname": ":credit_card:", "unicode": "1f4b3", "html": "&#128179;", "category": "o", "order": "1897"},
-		{"emoji": "🆔", "name": "id", "shortname": ":id:", "unicode": "1f194", "html": "&#127380;", "category": "s", "order": "2132"},
-		{"emoji": "㊙", "name": "secret", "shortname": ":secret:", "unicode": "3299", "html": "&#12953;", "category": "s", "order": "2156"},
-		{"emoji": "🎡", "name": "ferris_wheel", "shortname": ":ferris_wheel:", "unicode": "1f3a1", "html": "&#127905;", "category": "t", "order": "1594"},
-		{"emoji": "🎳", "name": "bowling", "shortname": ":bowling:", "unicode": "1f3b3", "html": "&#127923;", "category": "a", "order": "1789"},
-		{"emoji": "♎", "name": "libra", "shortname": ":libra:", "unicode": "264e", "html": "&#9806;", "category": "s", "order": "2041"},
-		{"emoji": "♍", "name": "virgo", "shortname": ":virgo:", "unicode": "264d", "html": "&#9805;", "category": "s", "order": "2040"},
-		{"emoji": "💈", "name": "barber", "shortname": ":barber:", "unicode": "1f488", "html": "&#128136;", "category": "o", "order": "1596"},
-		{"emoji": "👛", "name": "purse", "shortname": ":purse:", "unicode": "1f45b", "html": "&#128091;", "category": "p", "order": "1323"},
-		{"emoji": "🎢", "name": "roller_coaster", "shortname": ":roller_coaster:", "unicode": "1f3a2", "html": "&#127906;", "category": "t", "order": "1595"},
-		{"emoji": "🐀", "name": "rat", "shortname": ":rat:", "unicode": "1f400", "html": "&#128000;", "category": "n", "order": "1377"},
-		{"emoji": "📅", "name": "date", "shortname": ":date:", "unicode": "1f4c5", "html": "&#128197;", "category": "o", "order": "1925"},
-		{"emoji": "🏉", "name": "rugby_football", "shortname": ":rugby_football:", "unicode": "1f3c9", "html": "&#127945;", "category": "a", "order": "1786"},
-		{"emoji": "🐏", "name": "ram", "shortname": ":ram:", "unicode": "1f40f", "html": "&#128015;", "category": "n", "order": "1368"},
-		{"emoji": "🔼", "name": "arrow_up_small", "shortname": ":arrow_up_small:", "unicode": "1f53c", "html": "&#128316;", "category": "s", "order": "2058"},
-		{"emoji": "🔲", "name": "black_square_button", "shortname": ":black_square_button:", "unicode": "1f532", "html": "&#128306;", "category": "s", "order": "2175"},
-		{"emoji": "📴", "name": "mobile_phone_off", "shortname": ":mobile_phone_off:", "unicode": "1f4f4", "html": "&#128244;", "category": "s", "order": "2071"},
-		{"emoji": "🗼", "name": "tokyo_tower", "shortname": ":tokyo_tower:", "unicode": "1f5fc", "html": "&#128508;", "category": "t", "order": "1575"},
-		{"emoji": "㊗", "name": "congratulations", "shortname": ":congratulations:", "unicode": "3297", "html": "&#12951;", "category": "s", "order": "2155"},
-		{"emoji": "👘", "name": "kimono", "shortname": ":kimono:", "unicode": "1f458", "html": "&#128088;", "category": "p", "order": "1320"},
-		{"emoji": "🇷🇺", "name": "Russia", "shortname": ":ru:", "unicode": "", "html": "&#127479;", "category": "", "order": ""},
-		{"emoji": "🚢", "name": "ship", "shortname": ":ship:", "unicode": "1f6a2", "html": "&#128674;", "category": "t", "order": "1649"},
-		{"emoji": "🔎", "name": "mag_right", "shortname": ":mag_right:", "unicode": "1f50e", "html": "&#128270;", "category": "o", "order": "1866"},
-		{"emoji": "🔍", "name": "mag", "shortname": ":mag:", "unicode": "1f50d", "html": "&#128269;", "category": "o", "order": "1865"},
-		{"emoji": "🚒", "name": "fire_engine", "shortname": ":fire_engine:", "unicode": "1f692", "html": "&#128658;", "category": "t", "order": "1619"},
-		{"emoji": "🕦", "name": "clock1130", "shortname": ":clock1130:", "unicode": "1f566", "html": "&#128358;", "category": "s", "order": "1710"},
-		{"emoji": "🚓", "name": "police_car", "shortname": ":police_car:", "unicode": "1f693", "html": "&#128659;", "category": "t", "order": "1620"},
-		{"emoji": "🃏", "name": "black_joker", "shortname": ":black_joker:", "unicode": "1f0cf", "html": "&#127183;", "category": "s", "order": "1811"},
-		{"emoji": "🌉", "name": "bridge_at_night", "shortname": ":bridge_at_night:", "unicode": "1f309", "html": "&#127753;", "category": "t", "order": "1590"},
-		{"emoji": "📦", "name": "package", "shortname": ":package:", "unicode": "1f4e6", "html": "&#128230;", "category": "o", "order": "1907"},
-		{"emoji": "🚖", "name": "oncoming_taxi", "shortname": ":oncoming_taxi:", "unicode": "1f696", "html": "&#128662;", "category": "t", "order": "1623"},
-		{"emoji": "📆", "name": "calendar", "shortname": ":calendar:", "unicode": "1f4c6", "html": "&#128198;", "category": "o", "order": "1926"},
-		{"emoji": "🏇", "name": "horse_racing", "shortname": ":horse_racing:", "unicode": "1f3c7", "html": "&#127943;", "category": "a", "order": "769"},
-		{"emoji": "🐅", "name": "tiger2", "shortname": ":tiger2:", "unicode": "1f405", "html": "&#128005;", "category": "n", "order": "1354"},
-		{"emoji": "👢", "name": "boot", "shortname": ":boot:", "unicode": "1f462", "html": "&#128098;", "category": "p", "order": "1332"},
-		{"emoji": "🚑", "name": "ambulance", "shortname": ":ambulance:", "unicode": "1f691", "html": "&#128657;", "category": "t", "order": "1618"},
-		{"emoji": "🔳", "name": "white_square_button", "shortname": ":white_square_button:", "unicode": "1f533", "html": "&#128307;", "category": "s", "order": "2176"},
-		{"emoji": "🐗", "name": "boar", "shortname": ":boar:", "unicode": "1f417", "html": "&#128023;", "category": "n", "order": "1366"},
-		{"emoji": "🎒", "name": "school_satchel", "shortname": ":school_satchel:", "unicode": "1f392", "html": "&#127890;", "category": "p", "order": "1327"},
-		{"emoji": "➿", "name": "loop", "shortname": ":loop:", "unicode": "27bf", "html": "&#10175;", "category": "s", "order": "2091"},
-		{"emoji": "💷", "name": "pound", "shortname": ":pound:", "unicode": "1f4b7", "html": "&#128183;", "category": "o", "order": "1895"},
-		{"emoji": "ℹ", "name": "information_source", "shortname": ":information_source:", "unicode": "2139", "html": "&#8505;", "category": "s", "order": "2131"},
-		{"emoji": "🐂", "name": "ox", "shortname": ":ox:", "unicode": "1f402", "html": "&#128002;", "category": "n", "order": "1361"},
-		{"emoji": "🍙", "name": "rice_ball", "shortname": ":rice_ball:", "unicode": "1f359", "html": "&#127833;", "category": "d", "order": "1497"},
-		{"emoji": "🆚", "name": "vs", "shortname": ":vs:", "unicode": "1f19a", "html": "&#127386;", "category": "s", "order": "2141"},
-		{"emoji": "🔚", "name": "end", "shortname": ":end:", "unicode": "1f51a", "html": "&#128282;", "category": "s", "order": "2019"},
-		{"emoji": "🅿️", "name": "parking", "shortname": ":parking:", "unicode": "1f17f", "html": "&#127359;", "category": "s", "order": "2138"},
-		{"emoji": "👡", "name": "sandal", "shortname": ":sandal:", "unicode": "1f461", "html": "&#128097;", "category": "p", "order": "1331"},
-		{"emoji": "⛺", "name": "tent", "shortname": ":tent:", "unicode": "26fa", "html": "&#9978;", "category": "t", "order": "1583"},
-		{"emoji": "💺", "name": "seat", "shortname": ":seat:", "unicode": "1f4ba", "html": "&#128186;", "category": "t", "order": "1654"},
-		{"emoji": "🚕", "name": "taxi", "shortname": ":taxi:", "unicode": "1f695", "html": "&#128661;", "category": "t", "order": "1622"},
-		{"emoji": "◾", "name": "black_medium_small_square", "shortname": ":black_medium_small_square:", "unicode": "25fe", "html": "&#9726;", "category": "s", "order": "2164"},
-		{"emoji": "💼", "name": "briefcase", "shortname": ":briefcase:", "unicode": "1f4bc", "html": "&#128188;", "category": "p", "order": "1921"},
-		{"emoji": "📰", "name": "newspaper", "shortname": ":newspaper:", "unicode": "1f4f0", "html": "&#128240;", "category": "o", "order": "1886"},
-		{"emoji": "🎪", "name": "circus_tent", "shortname": ":circus_tent:", "unicode": "1f3aa", "html": "&#127914;", "category": "a", "order": "1597"},
-		{"emoji": "🔯", "name": "six_pointed_star", "shortname": ":six_pointed_star:", "unicode": "1f52f", "html": "&#128303;", "category": "s", "order": "2034"},
-		{"emoji": "🚹", "name": "mens", "shortname": ":mens:", "unicode": "1f6b9", "html": "&#128697;", "category": "s", "order": "1980"},
-		{"emoji": "🏰", "name": "european_castle", "shortname": ":european_castle:", "unicode": "1f3f0", "html": "&#127984;", "category": "t", "order": "1573"},
-		{"emoji": "🔦", "name": "flashlight", "shortname": ":flashlight:", "unicode": "1f526", "html": "&#128294;", "category": "o", "order": "1872"},
-		{"emoji": "🌁", "name": "foggy", "shortname": ":foggy:", "unicode": "1f301", "html": "&#127745;", "category": "t", "order": "1584"},
-		{"emoji": "⏫", "name": "arrow_double_up", "shortname": ":arrow_double_up:", "unicode": "23eb", "html": "&#9195;", "category": "s", "order": "2059"},
-		{"emoji": "🎍", "name": "bamboo", "shortname": ":bamboo:", "unicode": "1f38d", "html": "&#127885;", "category": "n", "order": "1765"},
-		{"emoji": "🎫", "name": "ticket", "shortname": ":ticket:", "unicode": "1f3ab", "html": "&#127915;", "category": "a", "order": "1774"},
-		{"emoji": "🚁", "name": "helicopter", "shortname": ":helicopter:", "unicode": "1f681", "html": "&#128641;", "category": "t", "order": "1655"},
-		{"emoji": "💽", "name": "minidisc", "shortname": ":minidisc:", "unicode": "1f4bd", "html": "&#128189;", "category": "o", "order": "1852"},
-		{"emoji": "🚍", "name": "oncoming_bus", "shortname": ":oncoming_bus:", "unicode": "1f68d", "html": "&#128653;", "category": "t", "order": "1615"},
-		{"emoji": "🍈", "name": "melon", "shortname": ":melon:", "unicode": "1f348", "html": "&#127816;", "category": "d", "order": "1450"},
-		{"emoji": "▫", "name": "white_small_square", "shortname": ":white_small_square:", "unicode": "25ab", "html": "&#9643;", "category": "s", "order": "2160"},
-		{"emoji": "🏤", "name": "european_post_office", "shortname": ":european_post_office:", "unicode": "1f3e4", "html": "&#127972;", "category": "t", "order": "1563"},
-		{"emoji": "🔟", "name": "keycap_ten", "shortname": ":keycap_ten:", "unicode": "1f51f", "html": "&#128287;", "category": "s", "order": "2118"},
-		{"emoji": "📓", "name": "notebook", "shortname": ":notebook:", "unicode": "1f4d3", "html": "&#128211;", "category": "o", "order": "1881"},
-		{"emoji": "🔕", "name": "no_bell", "shortname": ":no_bell:", "unicode": "1f515", "html": "&#128277;", "category": "s", "order": "1822"},
-		{"emoji": "🍢", "name": "oden", "shortname": ":oden:", "unicode": "1f362", "html": "&#127842;", "category": "d", "order": "1503"},
-		{"emoji": "🎏", "name": "flags", "shortname": ":flags:", "unicode": "1f38f", "html": "&#127887;", "category": "o", "order": "1767"},
-		{"emoji": "🎠", "name": "carousel_horse", "shortname": ":carousel_horse:", "unicode": "1f3a0", "html": "&#127904;", "category": "t", "order": "1593"},
-		{"emoji": "🐡", "name": "blowfish", "shortname": ":blowfish:", "unicode": "1f421", "html": "&#128033;", "category": "n", "order": "1411"},
-		{"emoji": "📈", "name": "chart_with_upwards_trend", "shortname": ":chart_with_upwards_trend:", "unicode": "1f4c8", "html": "&#128200;", "category": "o", "order": "1930"},
-		{"emoji": "🍠", "name": "sweet_potato", "shortname": ":sweet_potato:", "unicode": "1f360", "html": "&#127840;", "category": "d", "order": "1502"},
-		{"emoji": "🎿", "name": "ski", "shortname": ":ski:", "unicode": "1f3bf", "html": "&#127935;", "category": "a", "order": "1803"},
-		{"emoji": "🕛", "name": "clock12", "shortname": ":clock12:", "unicode": "1f55b", "html": "&#128347;", "category": "s", "order": "1687"},
-		{"emoji": "📶", "name": "signal_strength", "shortname": ":signal_strength:", "unicode": "1f4f6", "html": "&#128246;", "category": "s", "order": "2069"},
-		{"emoji": "🚧", "name": "construction", "shortname": ":construction:", "unicode": "1f6a7", "html": "&#128679;", "category": "t", "order": "1640"},
-		{"emoji": "#", "name": "", "shortname": "", "unicode": "", "html": "&#35;", "category": "", "order": ""},
-		{"emoji": "◼", "name": "black_medium_square", "shortname": ":black_medium_square:", "unicode": "25fc", "html": "&#9724;", "category": "s", "order": "2162"},
-		{"emoji": "📡", "name": "satellite", "shortname": ":satellite:", "unicode": "1f4e1", "html": "&#128225;", "category": "o", "order": "1869"},
-		{"emoji": "💶", "name": "euro", "shortname": ":euro:", "unicode": "1f4b6", "html": "&#128182;", "category": "o", "order": "1894"},
-		{"emoji": "👚", "name": "womans_clothes", "shortname": ":womans_clothes:", "unicode": "1f45a", "html": "&#128090;", "category": "p", "order": "1322"},
-		{"emoji": "📒", "name": "ledger", "shortname": ":ledger:", "unicode": "1f4d2", "html": "&#128210;", "category": "o", "order": "1882"},
-		{"emoji": "🐆", "name": "leopard", "shortname": ":leopard:", "unicode": "1f406", "html": "&#128006;", "category": "n", "order": "1355"},
-		{"emoji": "🔅", "name": "low_brightness", "shortname": ":low_brightness:", "unicode": "1f505", "html": "&#128261;", "category": "s", "order": "2067"},
-		{"emoji": "🕒", "name": "clock3", "shortname": ":clock3:", "unicode": "1f552", "html": "&#128338;", "category": "s", "order": "1693"},
-		{"emoji": "🏬", "name": "department_store", "shortname": ":department_store:", "unicode": "1f3ec", "html": "&#127980;", "category": "t", "order": "1570"},
-		{"emoji": "🚚", "name": "truck", "shortname": ":truck:", "unicode": "1f69a", "html": "&#128666;", "category": "t", "order": "1627"},
-		{"emoji": "🍶", "name": "sake", "shortname": ":sake:", "unicode": "1f376", "html": "&#127862;", "category": "d", "order": "1524"},
-		{"emoji": "🚃", "name": "railway_car", "shortname": ":railway_car:", "unicode": "1f683", "html": "&#128643;", "category": "t", "order": "1603"},
-		{"emoji": "🚤", "name": "speedboat", "shortname": ":speedboat:", "unicode": "1f6a4", "html": "&#128676;", "category": "t", "order": "1645"},
-		{"emoji": "🇰🇷", "name": "korea", "shortname": ":ko:", "unicode": "", "html": "&#127472;", "category": "", "order": ""},
-		{"emoji": "📼", "name": "vhs", "shortname": ":vhs:", "unicode": "1f4fc", "html": "&#128252;", "category": "o", "order": "1864"},
-		{"emoji": "🕐", "name": "clock1", "shortname": ":clock1:", "unicode": "1f550", "html": "&#128336;", "category": "s", "order": "1689"},
-		{"emoji": "⏬", "name": "arrow_double_down", "shortname": ":arrow_double_down:", "unicode": "23ec", "html": "&#9196;", "category": "s", "order": "2061"},
-		{"emoji": "🐃", "name": "water_buffalo", "shortname": ":water_buffalo:", "unicode": "1f403", "html": "&#128003;", "category": "n", "order": "1362"},
-		{"emoji": "🔽", "name": "arrow_down_small", "shortname": ":arrow_down_small:", "unicode": "1f53d", "html": "&#128317;", "category": "s", "order": "2060"},
-		{"emoji": "💴", "name": "yen", "shortname": ":yen:", "unicode": "1f4b4", "html": "&#128180;", "category": "o", "order": "1892"},
-		{"emoji": "🔇", "name": "mute", "shortname": ":mute:", "unicode": "1f507", "html": "&#128263;", "category": "s", "order": "1814"},
-		{"emoji": "🎽", "name": "running_shirt_with_sash", "shortname": ":running_shirt_with_sash:", "unicode": "1f3bd", "html": "&#127933;", "category": "a", "order": "1802"},
-		{"emoji": "⬜", "name": "white_large_square", "shortname": ":white_large_square:", "unicode": "2b1c", "html": "&#11036;", "category": "s", "order": "2166"},
-		{"emoji": "♿", "name": "wheelchair", "shortname": ":wheelchair:", "unicode": "267f", "html": "&#9855;", "category": "s", "order": "1979"},
-		{"emoji": "🕑", "name": "clock2", "shortname": ":clock2:", "unicode": "1f551", "html": "&#128337;", "category": "s", "order": "1691"},
-		{"emoji": "📎", "name": "paperclip", "shortname": ":paperclip:", "unicode": "1f4ce", "html": "&#128206;", "category": "o", "order": "1936"},
-		{"emoji": "🏧", "name": "atm", "shortname": ":atm:", "unicode": "1f3e7", "html": "&#127975;", "category": "s", "order": "1976"},
-		{"emoji": "🎦", "name": "cinema", "shortname": ":cinema:", "unicode": "1f3a6", "html": "&#127910;", "category": "s", "order": "2066"},
-		{"emoji": "🔭", "name": "telescope", "shortname": ":telescope:", "unicode": "1f52d", "html": "&#128301;", "category": "o", "order": "1868"},
-		{"emoji": "🎑", "name": "rice_scene", "shortname": ":rice_scene:", "unicode": "1f391", "html": "&#127889;", "category": "t", "order": "1769"},
-		{"emoji": "📘", "name": "blue_book", "shortname": ":blue_book:", "unicode": "1f4d8", "html": "&#128216;", "category": "o", "order": "1878"},
-		{"emoji": "◻️", "name": "white_medium_square", "shortname": ":white_medium_square:", "unicode": "25fb", "html": "&#9723;", "category": "s", "order": "2161"},
-		{"emoji": "📮", "name": "postbox", "shortname": ":postbox:", "unicode": "1f4ee", "html": "&#128238;", "category": "o", "order": "1912"},
-		{"emoji": "📧", "name": "e-mail", "shortname": ":e-mail:", "unicode": "1f4e7", "html": "&#128231;", "category": "o", "order": "1902"},
-		{"emoji": "🐁", "name": "mouse2", "shortname": ":mouse2:", "unicode": "1f401", "html": "&#128001;", "category": "n", "order": "1376"},
-		{"emoji": "🚄", "name": "bullettrain_side", "shortname": ":bullettrain_side:", "unicode": "1f684", "html": "&#128644;", "category": "t", "order": "1604"},
-		{"emoji": "🉐", "name": "ideograph_advantage", "shortname": ":ideograph_advantage:", "unicode": "1f250", "html": "&#127568;", "category": "s", "order": "2147"},
-		{"emoji": "🔩", "name": "nut_and_bolt", "shortname": ":nut_and_bolt:", "unicode": "1f529", "html": "&#128297;", "category": "o", "order": "1960"},
-		{"emoji": "🆖", "name": "ng", "shortname": ":ng:", "unicode": "1f196", "html": "&#127382;", "category": "s", "order": "2135"},
-		{"emoji": "🏨", "name": "hotel", "shortname": ":hotel:", "unicode": "1f3e8", "html": "&#127976;", "category": "t", "order": "1566"},
-		{"emoji": "🚾", "name": "wc", "shortname": ":wc:", "unicode": "1f6be", "html": "&#128702;", "category": "s", "order": "1984"},
-		{"emoji": "🏮", "name": "izakaya_lantern", "shortname": ":izakaya_lantern:", "unicode": "1f3ee", "html": "&#127982;", "category": "o", "order": "1873"},
-		{"emoji": "🔂", "name": "repeat_one", "shortname": ":repeat_one:", "unicode": "1f502", "html": "&#128258;", "category": "s", "order": "2050"},
-		{"emoji": "📬", "name": "mailbox_with_mail", "shortname": ":mailbox_with_mail:", "unicode": "1f4ec", "html": "&#128236;", "category": "o", "order": "1910"},
-		{"emoji": "📉", "name": "chart_with_downwards_trend", "shortname": ":chart_with_downwards_trend:", "unicode": "1f4c9", "html": "&#128201;", "category": "o", "order": "1931"},
-		{"emoji": "📗", "name": "green_book", "shortname": ":green_book:", "unicode": "1f4d7", "html": "&#128215;", "category": "o", "order": "1877"},
-		{"emoji": "🚜", "name": "tractor", "shortname": ":tractor:", "unicode": "1f69c", "html": "&#128668;", "category": "t", "order": "1629"},
-		{"emoji": "⛲", "name": "fountain", "shortname": ":fountain:", "unicode": "26f2", "html": "&#9970;", "category": "t", "order": "1582"},
-		{"emoji": "🚇", "name": "metro", "shortname": ":metro:", "unicode": "1f687", "html": "&#128647;", "category": "t", "order": "1607"},
-		{"emoji": "📋", "name": "clipboard", "shortname": ":clipboard:", "unicode": "1f4cb", "html": "&#128203;", "category": "o", "order": "1933"},
-		{"emoji": "📵", "name": "no_mobile_phones", "shortname": ":no_mobile_phones:", "unicode": "1f4f5", "html": "&#128245;", "category": "s", "order": "1998"},
-		{"emoji": "🕓", "name": "clock4", "shortname": ":clock4:", "unicode": "1f553", "html": "&#128339;", "category": "s", "order": "1695"},
-		{"emoji": "🚭", "name": "no_smoking", "shortname": ":no_smoking:", "unicode": "1f6ad", "html": "&#128685;", "category": "s", "order": "1994"},
-		{"emoji": "⬛", "name": "black_large_square", "shortname": ":black_large_square:", "unicode": "2b1b", "html": "&#11035;", "category": "s", "order": "2165"},
-		{"emoji": "🎰", "name": "slot_machine", "shortname": ":slot_machine:", "unicode": "1f3b0", "html": "&#127920;", "category": "a", "order": "1601"},
-		{"emoji": "🕔", "name": "clock5", "shortname": ":clock5:", "unicode": "1f554", "html": "&#128340;", "category": "s", "order": "1697"},
-		{"emoji": "🛁", "name": "bathtub", "shortname": ":bathtub:", "unicode": "1f6c1", "html": "&#128705;", "category": "o", "order": "1679"},
-		{"emoji": "📜", "name": "scroll", "shortname": ":scroll:", "unicode": "1f4dc", "html": "&#128220;", "category": "o", "order": "1884"},
-		{"emoji": "🚉", "name": "station", "shortname": ":station:", "unicode": "1f689", "html": "&#128649;", "category": "t", "order": "1609"},
-		{"emoji": "🍘", "name": "rice_cracker", "shortname": ":rice_cracker:", "unicode": "1f358", "html": "&#127832;", "category": "d", "order": "1496"},
-		{"emoji": "🏦", "name": "bank", "shortname": ":bank:", "unicode": "1f3e6", "html": "&#127974;", "category": "t", "order": "1565"},
-		{"emoji": "🔧", "name": "wrench", "shortname": ":wrench:", "unicode": "1f527", "html": "&#128295;", "category": "o", "order": "1959"},
-		{"emoji": "🈯️", "name": "u6307", "shortname": ":u6307:", "unicode": "1f22f", "html": "&#127535;", "category": "s", "order": "2146"},
-		{"emoji": "🚛", "name": "articulated_lorry", "shortname": ":articulated_lorry:", "unicode": "1f69b", "html": "&#128667;", "category": "t", "order": "1628"},
-		{"emoji": "📄", "name": "page_facing_up", "shortname": ":page_facing_up:", "unicode": "1f4c4", "html": "&#128196;", "category": "o", "order": "1885"},
-		{"emoji": "⛎", "name": "ophiuchus", "shortname": ":ophiuchus:", "unicode": "26ce", "html": "&#9934;", "category": "s", "order": "2047"},
-		{"emoji": "📊", "name": "bar_chart", "shortname": ":bar_chart:", "unicode": "1f4ca", "html": "&#128202;", "category": "o", "order": "1932"},
-		{"emoji": "🚷", "name": "no_pedestrians", "shortname": ":no_pedestrians:", "unicode": "1f6b7", "html": "&#128695;", "category": "s", "order": "1997"},
-		{"emoji": "🇨🇳", "name": "Chinea", "shortname": ":cn:", "unicode": "", "html": "&#127464;", "category": "", "order": ""},
-		{"emoji": "📳", "name": "vibration_mode", "shortname": ":vibration_mode:", "unicode": "1f4f3", "html": "&#128243;", "category": "s", "order": "2070"},
-		{"emoji": "🕙", "name": "clock10", "shortname": ":clock10:", "unicode": "1f559", "html": "&#128345;", "category": "s", "order": "1707"},
-		{"emoji": "🕘", "name": "clock9", "shortname": ":clock9:", "unicode": "1f558", "html": "&#128344;", "category": "s", "order": "1705"},
-		{"emoji": "🚅", "name": "bullettrain_front", "shortname": ":bullettrain_front:", "unicode": "1f685", "html": "&#128645;", "category": "t", "order": "1605"},
-		{"emoji": "🚐", "name": "minibus", "shortname": ":minibus:", "unicode": "1f690", "html": "&#128656;", "category": "t", "order": "1617"},
-		{"emoji": "🚊", "name": "tram", "shortname": ":tram:", "unicode": "1f68a", "html": "&#128650;", "category": "t", "order": "1610"},
-		{"emoji": "🕗", "name": "clock8", "shortname": ":clock8:", "unicode": "1f557", "html": "&#128343;", "category": "s", "order": "1703"},
-		{"emoji": "🈳", "name": "u7a7a", "shortname": ":u7a7a:", "unicode": "1f233", "html": "&#127539;", "category": "s", "order": "2154"},
-		{"emoji": "🚥", "name": "traffic_light", "shortname": ":traffic_light:", "unicode": "1f6a5", "html": "&#128677;", "category": "t", "order": "1638"},
-		{"emoji": "🚵🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚵🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚵🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚵🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚵🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚵‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🚵🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&#127999;", "category": "", "order": ""},
-		{"emoji": "🚵🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&#127998;", "category": "", "order": ""},
-		{"emoji": "🚵🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&#127997;", "category": "", "order": ""},
-		{"emoji": "🚵🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&#127996;", "category": "", "order": ""},
-		{"emoji": "🚵🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128693;&#127995;", "category": "", "order": ""},
-		{"emoji": "🚵", "name": "mountain_bicyclist", "shortname": ":mountain_bicyclist:", "unicode": "1f6b5", "html": "&#128693;", "category": "a", "order": "908"},
-		{"emoji": "🔬", "name": "microscope", "shortname": ":microscope:", "unicode": "1f52c", "html": "&#128300;", "category": "o", "order": "1867"},
-		{"emoji": "🏯", "name": "japanese_castle", "shortname": ":japanese_castle:", "unicode": "1f3ef", "html": "&#127983;", "category": "t", "order": "1572"},
-		{"emoji": "🔖", "name": "bookmark", "shortname": ":bookmark:", "unicode": "1f516", "html": "&#128278;", "category": "o", "order": "1889"},
-		{"emoji": "📑", "name": "bookmark_tabs", "shortname": ":bookmark_tabs:", "unicode": "1f4d1", "html": "&#128209;", "category": "o", "order": "1888"},
-		{"emoji": "👝", "name": "pouch", "shortname": ":pouch:", "unicode": "1f45d", "html": "&#128093;", "category": "p", "order": "1325"},
-		{"emoji": "🆎", "name": "ab", "shortname": ":ab:", "unicode": "1f18e", "html": "&#127374;", "category": "s", "order": "2126"},
-		{"emoji": "📃", "name": "page_with_curl", "shortname": ":page_with_curl:", "unicode": "1f4c3", "html": "&#128195;", "category": "o", "order": "1883"},
-		{"emoji": "🎴", "name": "flower_playing_cards", "shortname": ":flower_playing_cards:", "unicode": "1f3b4", "html": "&#127924;", "category": "s", "order": "1813"},
-		{"emoji": "🕚", "name": "clock11", "shortname": ":clock11:", "unicode": "1f55a", "html": "&#128346;", "category": "s", "order": "1709"},
-		{"emoji": "📠", "name": "fax", "shortname": ":fax:", "unicode": "1f4e0", "html": "&#128224;", "category": "o", "order": "1843"},
-		{"emoji": "🕖", "name": "clock7", "shortname": ":clock7:", "unicode": "1f556", "html": "&#128342;", "category": "s", "order": "1701"},
-		{"emoji": "◽", "name": "white_medium_small_square", "shortname": ":white_medium_small_square:", "unicode": "25fd", "html": "&#9725;", "category": "s", "order": "2163"},
-		{"emoji": "💱", "name": "currency_exchange", "shortname": ":currency_exchange:", "unicode": "1f4b1", "html": "&#128177;", "category": "s", "order": "1899"},
-		{"emoji": "🔉", "name": "sound", "shortname": ":sound:", "unicode": "1f509", "html": "&#128265;", "category": "s", "order": "1816"},
-		{"emoji": "💹", "name": "chart", "shortname": ":chart:", "unicode": "1f4b9", "html": "&#128185;", "category": "s", "order": "1898"},
-		{"emoji": "🆑", "name": "cl", "shortname": ":cl:", "unicode": "1f191", "html": "&#127377;", "category": "s", "order": "2128"},
-		{"emoji": "💾", "name": "floppy_disk", "shortname": ":floppy_disk:", "unicode": "1f4be", "html": "&#128190;", "category": "o", "order": "1853"},
-		{"emoji": "🏣", "name": "post_office", "shortname": ":post_office:", "unicode": "1f3e3", "html": "&#127971;", "category": "t", "order": "1562"},
-		{"emoji": "🔈", "name": "speaker", "shortname": ":speaker:", "unicode": "1f508", "html": "&#128264;", "category": "s", "order": "1815"},
-		{"emoji": "🗾", "name": "japan", "shortname": ":japan:", "unicode": "1f5fe", "html": "&#128510;", "category": "t", "order": "1543"},
-		{"emoji": "🈺", "name": "u55b6", "shortname": ":u55b6:", "unicode": "1f23a", "html": "&#127546;", "category": "s", "order": "2157"},
-		{"emoji": "🀄", "name": "mahjong", "shortname": ":mahjong:", "unicode": "1f004", "html": "&#126980;", "category": "s", "order": "1812"},
-		{"emoji": "📨", "name": "incoming_envelope", "shortname": ":incoming_envelope:", "unicode": "1f4e8", "html": "&#128232;", "category": "o", "order": "1903"},
-		{"emoji": "📙", "name": "orange_book", "shortname": ":orange_book:", "unicode": "1f4d9", "html": "&#128217;", "category": "o", "order": "1879"},
-		{"emoji": "🚻", "name": "restroom", "shortname": ":restroom:", "unicode": "1f6bb", "html": "&#128699;", "category": "s", "order": "1982"},
-		{"emoji": "🈚️", "name": "u7121", "shortname": ":u7121:", "unicode": "1f21a", "html": "&#127514;", "category": "s", "order": "2149"},
-		{"emoji": "🈶", "name": "u6709", "shortname": ":u6709:", "unicode": "1f236", "html": "&#127542;", "category": "s", "order": "2145"},
-		{"emoji": "📐", "name": "triangular_ruler", "shortname": ":triangular_ruler:", "unicode": "1f4d0", "html": "&#128208;", "category": "o", "order": "1939"},
-		{"emoji": "🚋", "name": "train", "shortname": ":train:", "unicode": "1f68b", "html": "&#128651;", "category": "t", "order": "1613"},
-		{"emoji": "🈸", "name": "u7533", "shortname": ":u7533:", "unicode": "1f238", "html": "&#127544;", "category": "s", "order": "2152"},
-		{"emoji": "🚎", "name": "trolleybus", "shortname": ":trolleybus:", "unicode": "1f68e", "html": "&#128654;", "category": "t", "order": "1616"},
-		{"emoji": "🈷", "name": "u6708", "shortname": ":u6708:", "unicode": "1f237", "html": "&#127543;", "category": "s", "order": "2144"},
-		{"emoji": "🔢", "name": "1234", "shortname": "", "unicode": "", "html": "&#128290;", "category": "", "order": ""},
-		{"emoji": "📔", "name": "notebook_with_decorative_cover", "shortname": ":notebook_with_decorative_cover:", "unicode": "1f4d4", "html": "&#128212;", "category": "o", "order": "1874"},
-		{"emoji": "🈲", "name": "u7981", "shortname": ":u7981:", "unicode": "1f232", "html": "&#127538;", "category": "s", "order": "2150"},
-		{"emoji": "🈵", "name": "u6e80", "shortname": ":u6e80:", "unicode": "1f235", "html": "&#127541;", "category": "s", "order": "2158"},
-		{"emoji": "📯", "name": "postal_horn", "shortname": ":postal_horn:", "unicode": "1f4ef", "html": "&#128239;", "category": "o", "order": "1820"},
-		{"emoji": "🏭", "name": "factory", "shortname": ":factory:", "unicode": "1f3ed", "html": "&#127981;", "category": "t", "order": "1571"},
-		{"emoji": "🚸", "name": "children_crossing", "shortname": ":children_crossing:", "unicode": "1f6b8", "html": "&#128696;", "category": "s", "order": "1990"},
-		{"emoji": "🚆", "name": "train2", "shortname": ":train2:", "unicode": "1f686", "html": "&#128646;", "category": "t", "order": "1606"},
-		{"emoji": "📏", "name": "straight_ruler", "shortname": ":straight_ruler:", "unicode": "1f4cf", "html": "&#128207;", "category": "o", "order": "1938"},
-		{"emoji": "📟", "name": "pager", "shortname": ":pager:", "unicode": "1f4df", "html": "&#128223;", "category": "o", "order": "1842"},
-		{"emoji": "🉑", "name": "accept", "shortname": ":accept:", "unicode": "1f251", "html": "&#127569;", "category": "s", "order": "2151"},
-		{"emoji": "🈴", "name": "u5408", "shortname": ":u5408:", "unicode": "1f234", "html": "&#127540;", "category": "s", "order": "2153"},
-		{"emoji": "🔏", "name": "lock_with_ink_pen", "shortname": ":lock_with_ink_pen:", "unicode": "1f50f", "html": "&#128271;", "category": "o", "order": "1946"},
-		{"emoji": "🕜", "name": "clock130", "shortname": ":clock130:", "unicode": "1f55c", "html": "&#128348;", "category": "s", "order": "1690"},
-		{"emoji": "🈂️", "name": "sa", "shortname": ":sa:", "unicode": "1f202", "html": "&#127490;", "category": "s", "order": "2143"},
-		{"emoji": "📤", "name": "outbox_tray", "shortname": ":outbox_tray:", "unicode": "1f4e4", "html": "&#128228;", "category": "o", "order": "1905"},
-		{"emoji": "🔀", "name": "twisted_rightwards_arrows", "shortname": ":twisted_rightwards_arrows:", "unicode": "1f500", "html": "&#128256;", "category": "s", "order": "2048"},
-		{"emoji": "📫", "name": "mailbox", "shortname": ":mailbox:", "unicode": "1f4eb", "html": "&#128235;", "category": "o", "order": "1908"},
-		{"emoji": "🚈", "name": "light_rail", "shortname": ":light_rail:", "unicode": "1f688", "html": "&#128648;", "category": "t", "order": "1608"},
-		{"emoji": "🕤", "name": "clock930", "shortname": ":clock930:", "unicode": "1f564", "html": "&#128356;", "category": "s", "order": "1706"},
-		{"emoji": "🚏", "name": "busstop", "shortname": ":busstop:", "unicode": "1f68f", "html": "&#128655;", "category": "t", "order": "1633"},
-		{"emoji": "📂", "name": "open_file_folder", "shortname": ":open_file_folder:", "unicode": "1f4c2", "html": "&#128194;", "category": "o", "order": "1923"},
-		{"emoji": "📁", "name": "file_folder", "shortname": ":file_folder:", "unicode": "1f4c1", "html": "&#128193;", "category": "o", "order": "1922"},
-		{"emoji": "🚰", "name": "potable_water", "shortname": ":potable_water:", "unicode": "1f6b0", "html": "&#128688;", "category": "s", "order": "1978"},
-		{"emoji": "📇", "name": "card_index", "shortname": ":card_index:", "unicode": "1f4c7", "html": "&#128199;", "category": "o", "order": "1929"},
-		{"emoji": "🕝", "name": "clock230", "shortname": ":clock230:", "unicode": "1f55d", "html": "&#128349;", "category": "s", "order": "1692"},
-		{"emoji": "🚝", "name": "monorail", "shortname": ":monorail:", "unicode": "1f69d", "html": "&#128669;", "category": "t", "order": "1611"},
-		{"emoji": "🕧", "name": "clock1230", "shortname": ":clock1230:", "unicode": "1f567", "html": "&#128359;", "category": "s", "order": "1688"},
-		{"emoji": "🕥", "name": "clock1030", "shortname": ":clock1030:", "unicode": "1f565", "html": "&#128357;", "category": "s", "order": "1708"},
-		{"emoji": "🔤", "name": "abc", "shortname": ":abc:", "unicode": "1f524", "html": "&#128292;", "category": "s", "order": "2124"},
-		{"emoji": "📪", "name": "mailbox_closed", "shortname": ":mailbox_closed:", "unicode": "1f4ea", "html": "&#128234;", "category": "o", "order": "1909"},
-		{"emoji": "🕟", "name": "clock430", "shortname": ":clock430:", "unicode": "1f55f", "html": "&#128351;", "category": "s", "order": "1696"},
-		{"emoji": "🚞", "name": "mountain_railway", "shortname": ":mountain_railway:", "unicode": "1f69e", "html": "&#128670;", "category": "t", "order": "1612"},
-		{"emoji": "🚯", "name": "do_not_litter", "shortname": ":do_not_litter:", "unicode": "1f6af", "html": "&#128687;", "category": "s", "order": "1995"},
-		{"emoji": "🕞", "name": "clock330", "shortname": ":clock330:", "unicode": "1f55e", "html": "&#128350;", "category": "s", "order": "1694"},
-		{"emoji": "➗", "name": "heavy_division_sign", "shortname": ":heavy_division_sign:", "unicode": "2797", "html": "&#10135;", "category": "s", "order": "2089"},
-		{"emoji": "🕢", "name": "clock730", "shortname": ":clock730:", "unicode": "1f562", "html": "&#128354;", "category": "s", "order": "1702"},
-		{"emoji": "🕠", "name": "clock530", "shortname": ":clock530:", "unicode": "1f560", "html": "&#128352;", "category": "s", "order": "1698"},
-		{"emoji": "🔠", "name": "capital_abcd", "shortname": ":capital_abcd:", "unicode": "1f520", "html": "&#128288;", "category": "s", "order": "2120"},
-		{"emoji": "📭", "name": "mailbox_with_no_mail", "shortname": ":mailbox_with_no_mail:", "unicode": "1f4ed", "html": "&#128237;", "category": "o", "order": "1911"},
-		{"emoji": "🔣", "name": "symbols", "shortname": ":symbols:", "unicode": "1f523", "html": "&#128291;", "category": "s", "order": "2123"},
-		{"emoji": "🚡", "name": "aerial_tramway", "shortname": ":aerial_tramway:", "unicode": "1f6a1", "html": "&#128673;", "category": "t", "order": "1658"},
-		{"emoji": "🕣", "name": "clock830", "shortname": ":clock830:", "unicode": "1f563", "html": "&#128355;", "category": "s", "order": "1704"},
-		{"emoji": "🕡", "name": "clock630", "shortname": ":clock630:", "unicode": "1f561", "html": "&#128353;", "category": "s", "order": "1700"},
-		{"emoji": "🔡", "name": "abcd", "shortname": ":abcd:", "unicode": "1f521", "html": "&#128289;", "category": "s", "order": "2121"},
-		{"emoji": "🚠", "name": "mountain_cableway", "shortname": ":mountain_cableway:", "unicode": "1f6a0", "html": "&#128672;", "category": "t", "order": "1657"},
-		{"emoji": "🈁", "name": "koko", "shortname": ":koko:", "unicode": "1f201", "html": "&#127489;", "category": "s", "order": "2142"},
-		{"emoji": "🛂", "name": "passport_control", "shortname": ":passport_control:", "unicode": "1f6c2", "html": "&#128706;", "category": "s", "order": "1985"},
-		{"emoji": "🚱", "name": "non-potable_water", "shortname": ":non-potable_water:", "unicode": "1f6b1", "html": "&#128689;", "category": "s", "order": "1996"},
-		{"emoji": "🚟", "name": "suspension_railway", "shortname": ":suspension_railway:", "unicode": "1f69f", "html": "&#128671;", "category": "t", "order": "1656"},
-		{"emoji": "🛄", "name": "baggage_claim", "shortname": ":baggage_claim:", "unicode": "1f6c4", "html": "&#128708;", "category": "s", "order": "1987"},
-		{"emoji": "🚳", "name": "no_bicycles", "shortname": ":no_bicycles:", "unicode": "1f6b3", "html": "&#128691;", "category": "s", "order": "1993"},
-		{"emoji": "🏳‍🌈", "name": "", "shortname": "", "unicode": "", "html": "&#127987;&zwj;&#127752;", "category": "", "order": ""},
-		{"emoji": "🕵🏿‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&#127999;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🕵🏾‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&#127998;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🕵🏽‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&#127997;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🕵🏼‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&#127996;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🕵🏻‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&#127995;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🕵‍♀", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&zwj;&#9792;", "category": "", "order": ""},
-		{"emoji": "🕵🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&#127999;", "category": "", "order": ""},
-		{"emoji": "🕵🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&#127998;", "category": "", "order": ""},
-		{"emoji": "🕵🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&#127997;", "category": "", "order": ""},
-		{"emoji": "🕵🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&#127996;", "category": "", "order": ""},
-		{"emoji": "🕵🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128373;&#127995;", "category": "", "order": ""},
-		{"emoji": "🕵", "name": "", "shortname": "", "unicode": "", "html": "&#128373;", "category": "", "order": ""},
-		{"emoji": "☹", "name": "", "shortname": "", "unicode": "", "html": "&#9785;", "category": "", "order": ""},
-		{"emoji": "☠", "name": "skull_and_crossbones", "shortname": ":skull_crossbones:", "unicode": "2620", "html": "&#9760;", "category": "o", "order": "81"},
-		{"emoji": "🤗", "name": "hugging_face", "shortname": ":hugging:", "unicode": "1f917", "html": "&#129303;", "category": "p", "order": "20"},
-		{"emoji": "🤖", "name": "", "shortname": "", "unicode": "", "html": "&#129302;", "category": "", "order": ""},
-		{"emoji": "🤕", "name": "", "shortname": "", "unicode": "", "html": "&#129301;", "category": "", "order": ""},
-		{"emoji": "🤔", "name": "thinking_face", "shortname": ":thinking:", "unicode": "1f914", "html": "&#129300;", "category": "p", "order": "21"},
-		{"emoji": "🤓", "name": "nerd_face", "shortname": ":nerd:", "unicode": "1f913", "html": "&#129299;", "category": "p", "order": "36"},
-		{"emoji": "🤒", "name": "", "shortname": "", "unicode": "", "html": "&#129298;", "category": "", "order": ""},
-		{"emoji": "🤑", "name": "", "shortname": "", "unicode": "", "html": "&#129297;", "category": "", "order": ""},
-		{"emoji": "🤐", "name": "zipper_mouth_face", "shortname": ":zipper_mouth:", "unicode": "1f910", "html": "&#129296;", "category": "p", "order": "30"},
-		{"emoji": "🙄", "name": "face_with_rolling_eyes", "shortname": ":rolling_eyes:", "unicode": "1f644", "html": "&#128580;", "category": "p", "order": "25"},
-		{"emoji": "🙃", "name": "upside_down_face", "shortname": ":upside_down:", "unicode": "1f643", "html": "&#128579;", "category": "p", "order": "45"},
-		{"emoji": "🙂", "name": "slightly_smiling_face", "shortname": ":slight_smile:", "unicode": "1f642", "html": "&#128578;", "category": "p", "order": "19"},
-		{"emoji": "🙁", "name": "", "shortname": "", "unicode": "", "html": "&#128577;", "category": "", "order": ""},
-		{"emoji": "🤘🏿", "name": "", "shortname": "", "unicode": "", "html": "&#129304;&#127999;", "category": "", "order": ""},
-		{"emoji": "🤘🏾", "name": "", "shortname": "", "unicode": "", "html": "&#129304;&#127998;", "category": "", "order": ""},
-		{"emoji": "🤘🏽", "name": "", "shortname": "", "unicode": "", "html": "&#129304;&#127997;", "category": "", "order": ""},
-		{"emoji": "🤘🏼", "name": "", "shortname": "", "unicode": "", "html": "&#129304;&#127996;", "category": "", "order": ""},
-		{"emoji": "🤘🏻", "name": "", "shortname": "", "unicode": "", "html": "&#129304;&#127995;", "category": "", "order": ""},
-		{"emoji": "🤘", "name": "", "shortname": "", "unicode": "", "html": "&#129304;", "category": "", "order": ""},
-		{"emoji": "🖖🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128406;&#127999;", "category": "", "order": ""},
-		{"emoji": "🖖🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128406;&#127998;", "category": "", "order": ""},
-		{"emoji": "🖖🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128406;&#127997;", "category": "", "order": ""},
-		{"emoji": "🖖🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128406;&#127996;", "category": "", "order": ""},
-		{"emoji": "🖖🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128406;&#127995;", "category": "", "order": ""},
-		{"emoji": "🖖", "name": "", "shortname": "", "unicode": "", "html": "&#128406;", "category": "", "order": ""},
-		{"emoji": "🖕🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128405;&#127999;", "category": "", "order": ""},
-		{"emoji": "🖕🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128405;&#127998;", "category": "", "order": ""},
-		{"emoji": "🖕🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128405;&#127997;", "category": "", "order": ""},
-		{"emoji": "🖕🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128405;&#127996;", "category": "", "order": ""},
-		{"emoji": "🖕🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128405;&#127995;", "category": "", "order": ""},
-		{"emoji": "🖕", "name": "middle_finger", "shortname": ":middle_finger:", "unicode": "1f595", "html": "&#128405;", "category": "p", "order": "1116"},
-		{"emoji": "🖐🏿", "name": "", "shortname": "", "unicode": "", "html": "&#128400;&#127999;", "category": "", "order": ""},
-		{"emoji": "🖐🏾", "name": "", "shortname": "", "unicode": "", "html": "&#128400;&#127998;", "category": "", "order": ""},
-		{"emoji": "🖐🏽", "name": "", "shortname": "", "unicode": "", "html": "&#128400;&#127997;", "category": "", "order": ""},
-		{"emoji": "🖐🏼", "name": "", "shortname": "", "unicode": "", "html": "&#128400;&#127996;", "category": "", "order": ""},
-		{"emoji": "🖐🏻", "name": "", "shortname": "", "unicode": "", "html": "&#128400;&#127995;", "category": "", "order": ""},
-		{"emoji": "🖐", "name": "", "shortname": "", "unicode": "", "html": "&#128400;", "category": "", "order": ""},
-		{"emoji": "✍🏿", "name": "", "shortname": "", "unicode": "", "html": "&#9997;&#127999;", "category": "", "order": ""},
-		{"emoji": "✍🏾", "name": "", "shortname": "", "unicode": "", "html": "&#9997;&#127998;", "category": "", "order": ""},
-		{"emoji": "✍🏽", "name": "", "shortname": "", "unicode": "", "html": "&#9997;&#127997;", "category": "", "order": ""},
-		{"emoji": "✍🏼", "name": "", "shortname": "", "unicode": "", "html": "&#9997;&#127996;", "category": "", "order": ""},
-		{"emoji": "✍🏻", "name": "", "shortname": "", "unicode": "", "html": "&#9997;&#127995;", "category": "", "order": ""},
-		{"emoji": "✍", "name": "writing_hand", "shortname": ":writing_hand:", "unicode": "270d", "html": "&#9997;", "category": "p", "order": "1230"},
-		{"emoji": "🕶", "name": "dark_sunglasses", "shortname": ":dark_sunglasses:", "unicode": "1f576", "html": "&#128374;", "category": "p", "order": "1315"},
-		{"emoji": "👁‍🗨", "name": "eye_speachbubble", "shortname": ":eye_speachbubble:", "unicode": "", "html": "&#128065;&zwj;&#128488;", "category": "", "order": ""},
-		{"emoji": "👁", "name": "eye", "shortname": ":eye:", "unicode": "1f441", "html": "&#128065;", "category": "p", "order": "1280"},
-		{"emoji": "🏋🏿‍♀", "name": "weightlifter_woman_darktone", "shortname": ":weightlifter_woman_dt:", "unicode": "", "html": "&#127947;&#127999;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "🏋🏾‍♀", "name": "weightlifter_woman_mediumdarktone", "shortname": ":weightlifter_woman_mdt:", "unicode": "", "html": "&#127947;&#127998;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "🏋🏽‍♀", "name": "weightlifter_woman_mediumtone", "shortname": ":weightlifter_woman_mt:", "unicode": "", "html": "&#127947;&#127997;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "🏋🏼‍♀", "name": "weightlifter_woman_mediumlighttone", "shortname": ":weightlifter_woman_mlt:", "unicode": "", "html": "&#127947;&#127996;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "🏋🏻‍♀", "name": "weightlifter_woman_lighttone", "shortname": ":weightlifter_woman_lt:", "unicode": "", "html": "&#127947;&#127995;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "🏋‍♀", "name": "weightlifter_woman", "shortname": ":weightlifter_woman:", "unicode": "", "html": "&#127947;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "🏋🏿", "name": "weightlifter_darktone", "shortname": ":weightlifter_dt:", "unicode": "", "html": "&#127947;&#127999;", "category": "a", "order": ""},
-		{"emoji": "🏋🏾", "name": "weightlifter_mediumdarktone", "shortname": ":weightlifter_mdt:", "unicode": "", "html": "&#127947;&#127998;", "category": "a", "order": ""},
-		{"emoji": "🏋🏽", "name": "weightlifter_mediumtone", "shortname": ":weightlifter_mt:", "unicode": "", "html": "&#127947;&#127997;", "category": "a", "order": ""},
-		{"emoji": "🏋🏼", "name": "weightlifter_mediumlighttone", "shortname": ":weightlifter_mlt:", "unicode": "", "html": "&#127947;&#127996;", "category": "a", "order": ""},
-		{"emoji": "🏋🏻", "name": "weightlifter_lighttone", "shortname": ":weightlifter_lt:", "unicode": "", "html": "&#127947;&#127995;", "category": "a", "order": ""},
-		{"emoji": "🏋", "name": "weightlifter", "shortname": ":weightlifter:", "unicode": "", "html": "&#127947;", "category": "a", "order": ""},
-		{"emoji": "⛹🏿‍♀", "name": "basketballer_woman_darktone", "shortname": ":basketballer_woman_dt:", "unicode": ":basketballer:", "html": "&#9977;&#127999;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "⛹🏾‍♀", "name": "basketballer_woman_mediumdarktone", "shortname": ":basketballer_woman_mdt:", "unicode": ":basketballer:", "html": "&#9977;&#127998;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "⛹🏽‍♀", "name": "basketballer_woman_mediumtone", "shortname": ":basketballer_woman_mt:", "unicode": ":basketballer:", "html": "&#9977;&#127997;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "⛹🏼‍♀", "name": "basketballer_woman_mediumlighttone", "shortname": ":basketballer_woman_mlt:", "unicode": ":basketballer:", "html": "&#9977;&#127996;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "⛹🏻‍♀", "name": "basketballer_woman_lighttone", "shortname": ":basketballer_woman_lt:", "unicode": ":basketballer:", "html": "&#9977;&#127995;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "⛹‍♀", "name": "basketballer_woman", "shortname": "", "unicode": ":basketballer_woman:", "html": "&#9977;&zwj;&#9792;", "category": "a", "order": ""},
-		{"emoji": "⛹🏿", "name": "basketballer_darktone", "shortname": "", "unicode": ":basketballer_dt:", "html": "&#9977;&#127999;", "category": "a", "order": ""},
-		{"emoji": "⛹🏾", "name": "basketballer_mediumdarktone", "shortname": "", "unicode": ":basketballer_mdt:", "html": "&#9977;&#127998;", "category": "a", "order": ""},
-		{"emoji": "⛹🏽", "name": "basketballer_mediumtone", "shortname": "", "unicode": ":basketballer_mt:", "html": "&#9977;&#127997;", "category": "a", "order": ""},
-		{"emoji": "⛹🏼", "name": "basketballer_mediumlighttone", "shortname": "", "unicode": ":basketballer_mlt:", "html": "&#9977;&#127996;", "category": "a", "order": ""},
-		{"emoji": "⛹🏻", "name": "basketballer_lighttone", "shortname": ":basketballer_lt:", "unicode": "", "html": "&#9977;&#127995;", "category": "a", "order": ""},
-		{"emoji": "⛹", "name": "basketballer", "shortname": ":basketballer:", "unicode": "", "html": "&#9977;", "category": "a", "order": ""},
-		{"emoji": "🕴", "name": "Man in Suit Levitating", "shortname": ":man_in_suit:", "unicode": "1f574", "html": "&#128372;", "category": "a", "order": "784"},
-		{"emoji": "🏌", "name": "golfer", "shortname": ":golfer:", "unicode": "1f3cc", "html": "&#127948;", "category": "a", "order": "782"},
-		{"emoji": "🏌‍♀", "name": "golfer_woman", "shortname": ":golfer_woman:", "unicode": "", "html": "&#127948;&zwj;&#9792;", "category": "a", "order": "783"},
-		{"emoji": "*️⃣", "name": "asterisk", "shortname": "*", "unicode": "", "html": "&#42;", "category": "s", "order": "2118"},
-		{"emoji": "❣️", "name": "heart_exclamation", "shortname": ":heart_exclamation:", "unicode": "2763", "html": "&#10083;", "category": "s", "order": "1300"},
-		{"emoji": "✡️", "name": "star_of_david", "shortname": ":star_of_david:", "unicode": "2721", "html": "&#10017;", "category": "s", "order": "2026"},
-		{"emoji": "✝️", "name": "cross", "shortname": ":cross:", "unicode": "271d", "html": "&#10013;", "category": "s", "order": "2029"},
-		{"emoji": "⚜", "name": "fleur-de-lis", "shortname": ":fleur-de-lis:", "unicode": "269c", "html": "&#9884;", "category": "s", "order": "2074"},
-		{"emoji": "⚛", "name": "atom", "shortname": ":atom:", "unicode": "269b", "html": "&#9883;", "category": "s", "order": "2024"},
-		{"emoji": "☸", "name": "wheel_of_dharma", "shortname": ":wheel_of_dharma:", "unicode": "2638", "html": "&#9784;", "category": "s", "order": "2027"},
-		{"emoji": "☯", "name": "yin_yang", "shortname": ":yin_yang:", "unicode": "262f", "html": "&#9775;", "category": "s", "order": "2028"},
-		{"emoji": "☮", "name": "peace", "shortname": ":peace:", "unicode": "262e", "html": "&#9774;", "category": "s", "order": "2032"},
-		{"emoji": "☪", "name": "star_and_crescent", "shortname": ":star_and_crescent:", "unicode": "262a", "html": "&#9770;", "category": "s", "order": "2031"},
-		{"emoji": "☦", "name": "orthodox_cross", "shortname": ":orthodox_cross:", "unicode": "2626", "html": "&#9766;", "category": "s", "order": "2030"},
-		{"emoji": "☣", "name": "biohazard", "shortname": ":biohazard:", "unicode": "2623", "html": "&#9763;", "category": "s", "order": "2001"},
-		{"emoji": "☢", "name": "radioactive", "shortname": ":radioactive:", "unicode": "2622", "html": "&#9762;", "category": "s", "order": "2000"},
-		{"emoji": "🛐", "name": "place_of_worship", "shortname": ":place_of_worship:", "unicode": "1f6d0", "html": "&#128720;", "category": "s", "order": "2023"},
-		{"emoji": "🗯", "name": "anger_right", "shortname": ":anger_right:", "unicode": "1f5ef", "html": "&#128495;", "category": "s", "order": "1311"},
-		{"emoji": "🕎", "name": "menorah", "shortname": ":menorah:", "unicode": "1f54e", "html": "&#128334;", "category": "s", "order": "2033"},
-		{"emoji": "🕉", "name": "om_symbol", "shortname": ":om_symbol:", "unicode": "1f549", "html": "&#128329;", "category": "s", "order": "2025"},
-		{"emoji": "⚱", "name": "", "shortname": "", "unicode": "", "html": "&#9905;", "category": "", "order": ""},
-		{"emoji": "⚰", "name": "coffin", "shortname": ":coffin:", "unicode": "26b0", "html": "&#9904;", "category": "o", "order": "1970"},
-		{"emoji": "⚙", "name": "gear", "shortname": ":gear:", "unicode": "2699", "html": "&#9881;", "category": "o", "order": "1961"},
-		{"emoji": "⚗", "name": "alembic", "shortname": ":alembic:", "unicode": "2697", "html": "&#9879;", "category": "o", "order": "1963"},
-		{"emoji": "⚖", "name": "scales", "shortname": ":scales:", "unicode": "2696", "html": "&#9878;", "category": "o", "order": "1964"},
-		{"emoji": "⚔", "name": "crossed_swords", "shortname": ":crossed_swords:", "unicode": "2694", "html": "&#9876;", "category": "o", "order": "1955"},
-		{"emoji": "⌨", "name": "keyboard", "shortname": ":keyboard:", "unicode": "2328", "html": "&#9000;", "category": "o", "order": "1849"},
-		{"emoji": "🛢", "name": "", "shortname": "", "unicode": "", "html": "&#128738;", "category": "", "order": ""},
-		{"emoji": "🛡", "name": "shield", "shortname": ":shield:", "unicode": "1f6e1", "html": "&#128737;", "category": "o", "order": "1958"},
-		{"emoji": "🛠", "name": "", "shortname": "", "unicode": "", "html": "&#128736;", "category": "", "order": ""},
-		{"emoji": "🛏", "name": "bed", "shortname": ":bed:", "unicode": "1f6cf", "html": "&#128719;", "category": "o", "order": "1669"},
-		{"emoji": "🛎", "name": "", "shortname": "", "unicode": "", "html": "&#128718;", "category": "", "order": ""},
-		{"emoji": "🛍", "name": "shopping_bags", "shortname": ":shopping_bags:", "unicode": "1f6cd", "html": "&#128717;", "category": "o", "order": "1326"},
-		{"emoji": "🛌", "name": "sleeping_accommodation", "shortname": ":sleeping_accommodation:", "unicode": "1f6cc", "html": "&#128716;", "category": "o", "order": "1663"},
-		{"emoji": "🛋", "name": "", "shortname": "", "unicode": "", "html": "&#128715;", "category": "", "order": ""},
-		{"emoji": "🗳", "name": "ballot_box", "shortname": ":ballot_box:", "unicode": "1f5f3", "html": "&#128499;", "category": "o", "order": "1913"},
-		{"emoji": "🗡", "name": "", "shortname": "", "unicode": "", "html": "&#128481;", "category": "", "order": ""},
-		{"emoji": "🗞", "name": "", "shortname": "", "unicode": "", "html": "&#128478;", "category": "", "order": ""},
-		{"emoji": "🗝", "name": "", "shortname": "", "unicode": "", "html": "&#128477;", "category": "", "order": ""},
-		{"emoji": "🗜", "name": "compression", "shortname": ":compression:", "unicode": "1f5dc", "html": "&#128476;", "category": "o", "order": "1962"},
-		{"emoji": "🗓", "name": "", "shortname": "", "unicode": "", "html": "&#128467;", "category": "", "order": ""},
-		{"emoji": "🗒", "name": "", "shortname": "", "unicode": "", "html": "&#128466;", "category": "", "order": ""},
-		{"emoji": "🗑", "name": "wastebasket", "shortname": ":wastebasket:", "unicode": "1f5d1", "html": "&#128465;", "category": "o", "order": "1943"},
-		{"emoji": "🗄", "name": "file_cabinet", "shortname": ":file_cabinet:", "unicode": "1f5c4", "html": "&#128452;", "category": "o", "order": "1942"},
-		{"emoji": "🗃", "name": "", "shortname": "", "unicode": "", "html": "&#128451;", "category": "", "order": ""},
-		{"emoji": "🗂", "name": "", "shortname": "", "unicode": "", "html": "&#128450;", "category": "", "order": ""},
-		{"emoji": "🖼", "name": "", "shortname": "", "unicode": "", "html": "&#128444;", "category": "", "order": ""},
-		{"emoji": "🖲", "name": "trackball", "shortname": ":trackball:", "unicode": "1f5b2", "html": "&#128434;", "category": "o", "order": "1851"},
-		{"emoji": "🖱", "name": "", "shortname": "", "unicode": "", "html": "&#128433;", "category": "", "order": ""},
-		{"emoji": "🖨", "name": "printer", "shortname": ":printer:", "unicode": "1f5a8", "html": "&#128424;", "category": "o", "order": "1848"},
-		{"emoji": "🖥", "name": "", "shortname": "", "unicode": "", "html": "&#128421;", "category": "", "order": ""},
-		{"emoji": "🖍", "name": "", "shortname": "", "unicode": "", "html": "&#128397;", "category": "", "order": ""},
-		{"emoji": "🖌", "name": "", "shortname": "", "unicode": "", "html": "&#128396;", "category": "", "order": ""},
-		{"emoji": "🖋", "name": "", "shortname": "", "unicode": "", "html": "&#128395;", "category": "", "order": ""},
-		{"emoji": "🖊", "name": "", "shortname": "", "unicode": "", "html": "&#128394;", "category": "", "order": ""},
-		{"emoji": "🖇", "name": "", "shortname": "", "unicode": "", "html": "&#128391;", "category": "", "order": ""},
-		{"emoji": "🕹", "name": "joystick", "shortname": ":joystick:", "unicode": "1f579", "html": "&#128377;", "category": "o", "order": "1805"},
-		{"emoji": "🕳", "name": "hole", "shortname": ":hole:", "unicode": "1f573", "html": "&#128371;", "category": "o", "order": "1313"},
-		{"emoji": "🕰", "name": "", "shortname": "", "unicode": "", "html": "&#128368;", "category": "", "order": ""},
-		{"emoji": "🕯", "name": "candle", "shortname": ":candle:", "unicode": "1f56f", "html": "&#128367;", "category": "o", "order": "1870"},
-		{"emoji": "📿", "name": "prayer_beads", "shortname": ":prayer_beads:", "unicode": "1f4ff", "html": "&#128255;", "category": "o", "order": "1338"},
-		{"emoji": "📽", "name": "", "shortname": "", "unicode": "", "html": "&#128253;", "category": "", "order": ""},
-		{"emoji": "📸", "name": "camera_with_flash", "shortname": ":camera_with_flash:", "unicode": "1f4f8", "html": "&#128248;", "category": "o", "order": "1862"},
-		{"emoji": "🏺", "name": "amphora", "shortname": ":amphora:", "unicode": "1f3fa", "html": "&#127994;", "category": "o", "order": "1537"},
-		{"emoji": "🏷", "name": "label", "shortname": ":label:", "unicode": "1f3f7", "html": "&#127991;", "category": "o", "order": "1890"},
-		{"emoji": "🏴", "name": "waving_black_flag", "shortname": ":flag_black:", "unicode": "1f3f4", "html": "&#127988;", "category": "o", "order": "2184"},
-		{"emoji": "🏳", "name": "waving_white_flag", "shortname": ":flag_white:", "unicode": "1f3f3", "html": "&#127987;", "category": "o", "order": "2185"},
-		{"emoji": "🎞", "name": "film_frames", "shortname": ":film_frames:", "unicode": "1f39e", "html": "&#127902;", "category": "o", "order": "1857"},
-		{"emoji": "🎛", "name": "control_knobs", "shortname": ":control_knobs:", "unicode": "1f39b", "html": "&#127899;", "category": "o", "order": "1828"},
-		{"emoji": "🎚", "name": "level_slider", "shortname": ":level_slider:", "unicode": "1f39a", "html": "&#127898;", "category": "o", "order": "1827"},
-		{"emoji": "🎙", "name": "", "shortname": "", "unicode": "", "html": "&#127897;", "category": "", "order": ""},
-		{"emoji": "🌡", "name": "thermometer", "shortname": ":thermometer:", "unicode": "1f321", "html": "&#127777;", "category": "o", "order": "1723"},
-		{"emoji": "🛳", "name": "", "shortname": "", "unicode": "", "html": "&#128755;", "category": "", "order": ""},
-		{"emoji": "🛰", "name": "", "shortname": "", "unicode": "", "html": "&#128752;", "category": "", "order": ""},
-		{"emoji": "🛬", "name": "airplane_arriving", "shortname": ":airplane_arriving:", "unicode": "1f6ec", "html": "&#128748;", "category": "t", "order": "1653"},
-		{"emoji": "🛫", "name": "airplane_departure", "shortname": ":airplane_departure:", "unicode": "1f6eb", "html": "&#128747;", "category": "t", "order": "1652"},
-		{"emoji": "🛩", "name": "", "shortname": "", "unicode": "", "html": "&#128745;", "category": "", "order": ""},
-		{"emoji": "🛥", "name": "", "shortname": "", "unicode": "", "html": "&#128741;", "category": "", "order": ""},
-		{"emoji": "🛤", "name": "railway_track", "shortname": ":railway_track:", "unicode": "1f6e4", "html": "&#128740;", "category": "t", "order": "1635"},
-		{"emoji": "🛣", "name": "motorway", "shortname": ":motorway:", "unicode": "1f6e3", "html": "&#128739;", "category": "t", "order": "1634"},
-		{"emoji": "🗺", "name": "", "shortname": "", "unicode": "", "html": "&#128506;", "category": "", "order": ""},
-		{"emoji": "🕍", "name": "synagogue", "shortname": ":synagogue:", "unicode": "1f54d", "html": "&#128333;", "category": "t", "order": "1579"},
-		{"emoji": "🕌", "name": "mosque", "shortname": ":mosque:", "unicode": "1f54c", "html": "&#128332;", "category": "t", "order": "1578"},
-		{"emoji": "🕋", "name": "kaaba", "shortname": ":kaaba:", "unicode": "1f54b", "html": "&#128331;", "category": "t", "order": "1581"},
-		{"emoji": "🏟", "name": "stadium", "shortname": ":stadium:", "unicode": "1f3df", "html": "&#127967;", "category": "t", "order": "1553"},
-		{"emoji": "🏞", "name": "", "shortname": "", "unicode": "", "html": "&#127966;", "category": "", "order": ""},
-		{"emoji": "🏝", "name": "", "shortname": "", "unicode": "", "html": "&#127965;", "category": "", "order": ""},
-		{"emoji": "🏜", "name": "desert", "shortname": ":desert:", "unicode": "1f3dc", "html": "&#127964;", "category": "t", "order": "1550"},
-		{"emoji": "🏛", "name": "classical_building", "shortname": ":classical_building:", "unicode": "1f3db", "html": "&#127963;", "category": "t", "order": "1554"},
-		{"emoji": "🏚", "name": "", "shortname": "", "unicode": "", "html": "&#127962;", "category": "", "order": ""},
-		{"emoji": "🏙", "name": "cityscape", "shortname": ":cityscape:", "unicode": "1f3d9", "html": "&#127961;", "category": "t", "order": "1557"},
-		{"emoji": "🏘", "name": "", "shortname": "", "unicode": "", "html": "&#127960;", "category": "", "order": ""},
-		{"emoji": "🏗", "name": "", "shortname": "", "unicode": "", "html": "&#127959;", "category": "", "order": ""},
-		{"emoji": "🏖", "name": "", "shortname": "", "unicode": "", "html": "&#127958;", "category": "", "order": ""},
-		{"emoji": "🏕", "name": "camping", "shortname": ":camping:", "unicode": "1f3d5", "html": "&#127957;", "category": "t", "order": "1548"},
-		{"emoji": "🏔", "name": "", "shortname": "", "unicode": "", "html": "&#127956;", "category": "", "order": ""},
-		{"emoji": "🏎", "name": "", "shortname": "", "unicode": "", "html": "&#127950;", "category": "", "order": ""},
-		{"emoji": "🏍", "name": "", "shortname": "", "unicode": "", "html": "&#127949;", "category": "", "order": ""},
-		{"emoji": "🏹", "name": "bow_and_arrow", "shortname": ":bow_and_arrow:", "unicode": "1f3f9", "html": "&#127993;", "category": "a", "order": "1957"},
-		{"emoji": "🏸", "name": "", "shortname": "", "unicode": "", "html": "&#127992;", "category": "", "order": ""},
-		{"emoji": "🏵", "name": "rosette", "shortname": ":rosette:", "unicode": "1f3f5", "html": "&#127989;", "category": "n", "order": "1430"},
-		{"emoji": "🏓", "name": "", "shortname": "", "unicode": "", "html": "&#127955;", "category": "", "order": ""},
-		{"emoji": "🏒", "name": "", "shortname": "", "unicode": "", "html": "&#127954;", "category": "", "order": ""},
-		{"emoji": "🏑", "name": "", "shortname": "", "unicode": "", "html": "&#127953;", "category": "", "order": ""},
-		{"emoji": "🏐", "name": "volleyball", "shortname": ":volleyball:", "unicode": "1f3d0", "html": "&#127952;", "category": "a", "order": "1784"},
-		{"emoji": "🏏", "name": "", "shortname": "", "unicode": "", "html": "&#127951;", "category": "", "order": ""},
-		{"emoji": "🏅", "name": "medal", "shortname": ":medal:", "unicode": "1f3c5", "html": "&#127941;", "category": "a", "order": "1777"},
-		{"emoji": "🎟", "name": "", "shortname": "", "unicode": "", "html": "&#127903;", "category": "", "order": ""},
-		{"emoji": "🎗", "name": "reminder_ribbon", "shortname": ":reminder_ribbon:", "unicode": "1f397", "html": "&#127895;", "category": "a", "order": "1772"},
-		{"emoji": "🎖", "name": "", "shortname": "", "unicode": "", "html": "&#127894;", "category": "", "order": ""},
-		{"emoji": "🧀", "name": "", "shortname": "", "unicode": "", "html": "&#129472;", "category": "", "order": ""},
-		{"emoji": "🍿", "name": "popcorn", "shortname": ":popcorn:", "unicode": "1f37f", "html": "&#127871;", "category": "d", "order": "1494"},
-		{"emoji": "🍾", "name": "champagne", "shortname": ":champagne:", "unicode": "1f37e", "html": "&#127870;", "category": "d", "order": "1525"},
-		{"emoji": "🍽", "name": "", "shortname": "", "unicode": "", "html": "&#127869;", "category": "", "order": ""},
-		{"emoji": "🌶", "name": "hot_pepper", "shortname": ":hot_pepper:", "unicode": "1f336", "html": "&#127798;", "category": "d", "order": "1469"},
-		{"emoji": "🌯", "name": "burrito", "shortname": ":burrito:", "unicode": "1f32f", "html": "&#127791;", "category": "d", "order": "1487"},
-		{"emoji": "🌮", "name": "taco", "shortname": ":taco:", "unicode": "1f32e", "html": "&#127790;", "category": "d", "order": "1486"},
-		{"emoji": "🌭", "name": "hotdog", "shortname": ":hotdog:", "unicode": "1f32d", "html": "&#127789;", "category": "d", "order": "1485"},
-		{"emoji": "☘", "name": "shamrock", "shortname": ":shamrock:", "unicode": "2618", "html": "&#9752;", "category": "n", "order": "1444"},
-		{"emoji": "☄", "name": "comet", "shortname": ":comet:", "unicode": "2604", "html": "&#9732;", "category": "n", "order": "1752"},
-		{"emoji": "☃️", "name": "", "shortname": "", "unicode": "", "html": "&#9731;", "category": "", "order": ""},
-		{"emoji": "☂️", "name": "", "shortname": "", "unicode": "", "html": "&#9730;", "category": "", "order": ""},
-		{"emoji": "🦄", "name": "", "shortname": "", "unicode": "", "html": "&#129412;", "category": "", "order": ""},
-		{"emoji": "🦃", "name": "turkey", "shortname": ":turkey:", "unicode": "1f983", "html": "&#129411;", "category": "n", "order": "1387"},
-		{"emoji": "🦂", "name": "scorpion", "shortname": ":scorpion:", "unicode": "1f982", "html": "&#129410;", "category": "n", "order": "1426"},
-		{"emoji": "🦁", "name": "lion_face", "shortname": ":lion_face:", "unicode": "1f981", "html": "&#129409;", "category": "n", "order": "1352"},
-		{"emoji": "🦀", "name": "crab", "shortname": ":crab:", "unicode": "1f980", "html": "&#129408;", "category": "n", "order": "1415"},
-		{"emoji": "🕸", "name": "spider_web", "shortname": ":spider_web:", "unicode": "1f578", "html": "&#128376;", "category": "n", "order": "1425"},
-		{"emoji": "🕷", "name": "spider", "shortname": ":spider:", "unicode": "1f577", "html": "&#128375;", "category": "n", "order": "1424"},
-		{"emoji": "🕊", "name": "", "shortname": "", "unicode": "", "html": "&#128330;", "category": "", "order": ""},
-		{"emoji": "🐿", "name": "chipmunk", "shortname": ":chipmunk:", "unicode": "1f43f", "html": "&#128063;", "category": "n", "order": "1381"},
-		{"emoji": "🌬", "name": "wind_blowing_face", "shortname": ":wind_blowing_face:", "unicode": "1f32c", "html": "&#127788;", "category": "n", "order": "1741"},
-		{"emoji": "🌫", "name": "fog", "shortname": ":fog:", "unicode": "1f32b", "html": "&#127787;", "category": "n", "order": "1740"},
-		{"emoji": "🌪", "name": "", "shortname": "", "unicode": "", "html": "&#127786;", "category": "", "order": ""},
-		{"emoji": "🌩", "name": "", "shortname": "", "unicode": "", "html": "&#127785;", "category": "", "order": ""},
-		{"emoji": "🌨", "name": "", "shortname": "", "unicode": "", "html": "&#127784;", "category": "", "order": ""},
-		{"emoji": "🌧", "name": "", "shortname": "", "unicode": "", "html": "&#127783;", "category": "", "order": ""},
-		{"emoji": "🌦", "name": "", "shortname": "", "unicode": "", "html": "&#127782;", "category": "", "order": ""},
-		{"emoji": "🌥", "name": "", "shortname": "", "unicode": "", "html": "&#127781;", "category": "", "order": ""},
-		{"emoji": "🌤", "name": "", "shortname": "", "unicode": "", "html": "&#127780;", "category": "", "order": ""},
-		{"emoji": "🗣", "name": "", "shortname": "", "unicode": "", "html": "&#128483;", "category": "", "order": ""},
-		{"emoji": "⏺", "name": "", "shortname": "", "unicode": "", "html": "&#9210;", "category": "", "order": ""},
-		{"emoji": "⏹", "name": "", "shortname": "", "unicode": "", "html": "&#9209;", "category": "", "order": ""},
-		{"emoji": "⏸", "name": "", "shortname": "", "unicode": "", "html": "&#9208;", "category": "", "order": ""},
-		{"emoji": "⏯", "name": "play_pause", "shortname": ":play_pause:", "unicode": "23ef", "html": "&#9199;", "category": "s", "order": "2054"},
-		{"emoji": "⏮", "name": "track_previous", "shortname": ":track_previous:", "unicode": "23ee", "html": "&#9198;", "category": "s", "order": "2057"},
-		{"emoji": "⏭", "name": "track_next", "shortname": ":track_next:", "unicode": "23ed", "html": "&#9197;", "category": "s", "order": "2053"},
-		{"emoji": "⛱", "name": "beach_umbrella", "shortname": ":beach_umbrella:", "unicode": "26f1", "html": "&#9969;", "category": "o", "order": "1747"},
-		{"emoji": "⛓", "name": "chains", "shortname": ":chains:", "unicode": "26d3", "html": "&#9939;", "category": "o", "order": "1966"},
-		{"emoji": "⛏", "name": "pick", "shortname": ":pick:", "unicode": "26cf", "html": "&#9935;", "category": "o", "order": "1951"},
-		{"emoji": "⚒", "name": "", "shortname": "", "unicode": "", "html": "&#9874;", "category": "", "order": ""},
-		{"emoji": "⏲", "name": "", "shortname": "", "unicode": "", "html": "&#9202;", "category": "", "order": ""},
-		{"emoji": "⏱", "name": "stopwatch", "shortname": ":stopwatch:", "unicode": "23f1", "html": "&#9201;", "category": "o", "order": "1684"},
-		{"emoji": "⛴", "name": "ferry", "shortname": ":ferry:", "unicode": "26f4", "html": "&#9972;", "category": "t", "order": "1647"},
-		{"emoji": "⛰", "name": "mountain", "shortname": ":mountain:", "unicode": "26f0", "html": "&#9968;", "category": "t", "order": "1545"},
-		{"emoji": "⛩", "name": "shinto_shrine", "shortname": ":shinto_shrine:", "unicode": "2.6E+10", "html": "&#9961;", "category": "t", "order": "1580"},
-		{"emoji": "⛸", "name": "ice_skate", "shortname": ":ice_skate:", "unicode": "26f8", "html": "&#9976;", "category": "a", "order": "1800"},
-		{"emoji": "⛷", "name": "skier", "shortname": ":skier:", "unicode": "26f7", "html": "&#9975;", "category": "a", "order": "775"},
-		{"emoji": "⛈", "name": "", "shortname": "", "unicode": "", "html": "&#9928;", "category": "", "order": ""},
-		{"emoji": "⛑", "name": "", "shortname": "", "unicode": "", "html": "&#9937;", "category": "", "order": ""},
-		{"emoji": "🇦🇨", "name": "Ascension Island", "shortname": ":flag_ac:", "unicode": "1f1e6-1f1e8", "html": "&#127462;&#127464;", "category": "f", "order": "2187"},
-		{"emoji": "🇦🇩", "name": "Andorra", "shortname": ":flag_ad:", "unicode": "1f1e6-1f1e9", "html": "&#127462;&#127465;", "category": "f", "order": "2188"},
-		{"emoji": "🇦🇪", "name": "United Arab Emirates", "shortname": ":flag_ae:", "unicode": "1f1e6-1f1ea", "html": "&#127462;&#127466;", "category": "f", "order": "2189"},
-		{"emoji": "🇦🇫", "name": "Afghanistan", "shortname": ":flag_af:", "unicode": "1f1e6-1f1eb", "html": "&#127462;&#127467;", "category": "f", "order": "2190"},
-		{"emoji": "🇦🇬", "name": "Antigua and Barbuda", "shortname": ":flag_ag:", "unicode": "1f1e6-1f1ec", "html": "&#127462;&#127468;", "category": "f", "order": "2191"},
-		{"emoji": "🇦🇮", "name": "Anguilla", "shortname": ":flag_ai:", "unicode": "1f1e6-1f1ee", "html": "&#127462;&#127470;", "category": "f", "order": "2192"},
-		{"emoji": "🇦🇱", "name": "Albania", "shortname": ":flag_al:", "unicode": "1f1e6-1f1f1", "html": "&#127462;&#127473;", "category": "f", "order": "2193"},
-		{"emoji": "🇦🇲", "name": "Armenia", "shortname": ":flag_am:", "unicode": "1f1e6-1f1f2", "html": "&#127462;&#127474;", "category": "f", "order": "2194"},
-		{"emoji": "🇦🇴", "name": "Angola", "shortname": ":flag-ao:", "unicode": "1f1e6-1f1f4", "html": "&#127462;&#127476;", "category": "f", "order": "2195"},
-		{"emoji": "🇦🇶", "name": "Antarctica", "shortname": ":flag-aq:", "unicode": "1f1e6-1f1f6", "html": "&#127462;&#127478;", "category": "f", "order": "2196"},
-		{"emoji": "🇦🇷", "name": "Argentina", "shortname": ":flag-ar:", "unicode": "1f1e6-1f1f7", "html": "&#127462;&#127479;", "category": "f", "order": "2197"},
-		{"emoji": "🇦🇸", "name": "American Samoa", "shortname": ":flag-as:", "unicode": "1f1e6-1f1f8", "html": "&#127462;&#127480;", "category": "f", "order": "2198"},
-		{"emoji": "🇦🇹", "name": "Austria", "shortname": ":flag-at:", "unicode": "1f1e6-1f1f9", "html": "&#127462;&#127481;", "category": "f", "order": "2199"},
-		{"emoji": "🇦🇺", "name": "Australia", "shortname": ":flag-au:", "unicode": "1f1e6-1f1fa", "html": "&#127462;&#127482;", "category": "f", "order": "2200"},
-		{"emoji": "🇦🇼", "name": "Aruba", "shortname": ":flag-aw:", "unicode": "1f1e6-1f1fc", "html": "&#127462;&#127484;", "category": "f", "order": "2201"},
-		{"emoji": "🇦🇽", "name": "Åland Islands", "shortname": ":flag-ax:", "unicode": "1f1e6-1f1fd", "html": "&#127462;&#127485;", "category": "f", "order": "2202"},
-		{"emoji": "🇦🇿", "name": "Azerbaijan", "shortname": ":flag-az:", "unicode": "1f1e6-1f1ff", "html": "&#127462;&#127487;", "category": "f", "order": "2203"},
-		{"emoji": "🇧🇦", "name": "Bosnia and Herzegovina", "shortname": ":flag-ba:", "unicode": "1f1e7-1f1e6", "html": "&#127463;&#127462;", "category": "f", "order": "2204"},
-		{"emoji": "🇧🇧", "name": "Barbados", "shortname": ":flag-bb:", "unicode": "1f1e7-1f1e7", "html": "&#127463;&#127463;", "category": "f", "order": "2205"},
-		{"emoji": "🇧🇩", "name": "Bangladesh", "shortname": ":flag-bd:", "unicode": "1f1e7-1f1e9", "html": "&#127463;&#127465;", "category": "f", "order": "2206"},
-		{"emoji": "🇧🇪", "name": "Belgium", "shortname": ":flag-be:", "unicode": "1f1e7-1f1ea", "html": "&#127463;&#127466;", "category": "f", "order": "2207"},
-		{"emoji": "🇧🇫", "name": "Burkina Faso", "shortname": ":flag-bf:", "unicode": "1f1e7-1f1eb", "html": "&#127463;&#127467;", "category": "f", "order": "2208"},
-		{"emoji": "🇧🇬", "name": "Bulgaria", "shortname": ":flag-bg:", "unicode": "1f1e7-1f1ec", "html": "&#127463;&#127468;", "category": "f", "order": "2209"},
-		{"emoji": "🇧🇭", "name": "Bahrain", "shortname": ":flag-bh:", "unicode": "1f1e7-1f1ed", "html": "&#127463;&#127469;", "category": "f", "order": "2210"},
-		{"emoji": "🇧🇮", "name": "Burundi", "shortname": ":flag-bi:", "unicode": "1f1e7-1f1ee", "html": "&#127463;&#127470;", "category": "f", "order": "2211"},
-		{"emoji": "🇧🇯", "name": "Benin", "shortname": ":flag-bj:", "unicode": "1f1e7-1f1ef", "html": "&#127463;&#127471;", "category": "f", "order": "2212"},
-		{"emoji": "🇧🇱", "name": "St. Barthélemy", "shortname": ":flag-bl:", "unicode": "1f1e7-1f1f1", "html": "&#127463;&#127473;", "category": "f", "order": "2213"},
-		{"emoji": "🇧🇲", "name": "Bermuda", "shortname": ":flag-bm:", "unicode": "1f1e7-1f1f2", "html": "&#127463;&#127474;", "category": "f", "order": "2214"},
-		{"emoji": "🇧🇳", "name": "Brunei", "shortname": ":flag-bn:", "unicode": "1f1e7-1f1f3", "html": "&#127463;&#127475;", "category": "f", "order": "2215"},
-		{"emoji": "🇧🇴", "name": "Bolivia", "shortname": ":flag-bo:", "unicode": "1f1e7-1f1f4", "html": "&#127463;&#127476;", "category": "f", "order": "2216"},
-		{"emoji": "🇧🇶", "name": "Caribbean Netherlands", "shortname": ":flag-bq:", "unicode": "1f1e7-1f1f6", "html": "&#127463;&#127478;", "category": "f", "order": "2217"},
-		{"emoji": "🇧🇷", "name": "Brazil", "shortname": ":flag-br:", "unicode": "1f1e7-1f1f7", "html": "&#127463;&#127479;", "category": "f", "order": "2218"},
-		{"emoji": "🇧🇸", "name": "Bahamas", "shortname": ":flag-bs:", "unicode": "1f1e7-1f1f8", "html": "&#127463;&#127480;", "category": "f", "order": "2219"},
-		{"emoji": "🇧🇹", "name": "Bhutan", "shortname": ":flag-bt:", "unicode": "1f1e7-1f1f9", "html": "&#127463;&#127481;", "category": "f", "order": "2220"},
-		{"emoji": "🇧🇻", "name": "Bouvet Island", "shortname": ":flag-bv:", "unicode": "1f1e7-1f1fb", "html": "&#127463;&#127483;", "category": "f", "order": "2221"},
-		{"emoji": "🇧🇼", "name": "Botswana", "shortname": ":flag-bw:", "unicode": "1f1e7-1f1fc", "html": "&#127463;&#127484;", "category": "f", "order": "2222"},
-		{"emoji": "🇧🇾", "name": "Belarus", "shortname": ":flag-by:", "unicode": "1f1e7-1f1fe", "html": "&#127463;&#127486;", "category": "f", "order": "2223"},
-		{"emoji": "🇧🇿", "name": "Belize", "shortname": ":flag-bz:", "unicode": "1f1e7-1f1ff", "html": "&#127463;&#127487;", "category": "f", "order": "2224"},
-		{"emoji": "🇨🇦", "name": "Canada", "shortname": ":flag-ca:", "unicode": "1f1e8-1f1e6", "html": "&#127464;&#127462;", "category": "f", "order": "2225"},
-		{"emoji": "🇨🇨", "name": "Cocos (Keeling) Islands", "shortname": ":flag-cc:", "unicode": "1f1e8-1f1e8", "html": "&#127464;&#127464;", "category": "f", "order": "2226"},
-		{"emoji": "🇨🇩", "name": "Congo - Kinshasa", "shortname": ":flag-cd:", "unicode": "1f1e8-1f1e9", "html": "&#127464;&#127465;", "category": "f", "order": "2227"},
-		{"emoji": "🇨🇫", "name": "Central African Republic", "shortname": ":flag-cf:", "unicode": "1f1e8-1f1eb", "html": "&#127464;&#127467;", "category": "f", "order": "2228"},
-		{"emoji": "🇨🇬", "name": "Congo - Brazzaville", "shortname": ":flag-cg:", "unicode": "1f1e8-1f1ec", "html": "&#127464;&#127468;", "category": "f", "order": "2229"},
-		{"emoji": "🇨🇭", "name": "Switzerland", "shortname": ":flag-ch:", "unicode": "1f1e8-1f1ed", "html": "&#127464;&#127469;", "category": "f", "order": "2230"},
-		{"emoji": "🇨🇮", "name": "Côte d'Ivoire", "shortname": ":flag-ci:", "unicode": "1f1e8-1f1ee", "html": "&#127464;&#127470;", "category": "f", "order": "2231"},
-		{"emoji": "🇨🇰", "name": "Cook Islands", "shortname": ":flag-ck:", "unicode": "1f1e8-1f1f0", "html": "&#127464;&#127472;", "category": "f", "order": "2232"},
-		{"emoji": "🇨🇱", "name": "Chile", "shortname": ":flag-cl:", "unicode": "1f1e8-1f1f1", "html": "&#127464;&#127473;", "category": "f", "order": "2233"},
-		{"emoji": "🇨🇲", "name": "Cameroon", "shortname": ":flag-cm:", "unicode": "1f1e8-1f1f2", "html": "&#127464;&#127474;", "category": "f", "order": "2234"},
-		{"emoji": "🇨🇳", "name": "China", "shortname": ":flag-cn:", "unicode": "1f1e8-1f1f3", "html": "&#127464;&#127475;", "category": "f", "order": "2235"},
-		{"emoji": "🇨🇴", "name": "Colombia", "shortname": ":flag-co:", "unicode": "1f1e8-1f1f4", "html": "&#127464;&#127476;", "category": "f", "order": "2236"},
-		{"emoji": "🇨🇵", "name": "Clipperton Island", "shortname": ":flag-cp:", "unicode": "1f1e8-1f1f5", "html": "&#127464;&#127477;", "category": "f", "order": "2237"},
-		{"emoji": "🇨🇷", "name": "Costa Rica", "shortname": ":flag-cr:", "unicode": "1f1e8-1f1f7", "html": "&#127464;&#127479;", "category": "f", "order": "2238"},
-		{"emoji": "🇨🇺", "name": "Cuba", "shortname": ":flag-cu:", "unicode": "1f1e8-1f1fa", "html": "&#127464;&#127482;", "category": "f", "order": "2239"},
-		{"emoji": "🇨🇻", "name": "Cape Verde", "shortname": ":flag-cv:", "unicode": "1f1e8-1f1fb", "html": "&#127464;&#127483;", "category": "f", "order": "2240"},
-		{"emoji": "🇨🇼", "name": "Curaçao", "shortname": ":flag-cw:", "unicode": "1f1e8-1f1fc", "html": "&#127464;&#127484;", "category": "f", "order": "2241"},
-		{"emoji": "🇨🇽", "name": "Christmas Island", "shortname": ":flag-cx:", "unicode": "1f1e8-1f1fd", "html": "&#127464;&#127485;", "category": "f", "order": "2242"},
-		{"emoji": "🇨🇾", "name": "Cyprus", "shortname": ":flag-cy:", "unicode": "1f1e8-1f1fe", "html": "&#127464;&#127486;", "category": "f", "order": "2243"},
-		{"emoji": "🇨🇿", "name": "Czech Republic", "shortname": ":flag-cz:", "unicode": "1f1e8-1f1ff", "html": "&#127464;&#127487;", "category": "f", "order": "2244"},
-		{"emoji": "🇩🇪", "name": "Germany", "shortname": ":flag-de:", "unicode": "1f1e9-1f1ea", "html": "&#127465;&#127466;", "category": "f", "order": "2245"},
-		{"emoji": "🇩🇬", "name": "Diego Garcia", "shortname": ":flag-dg:", "unicode": "1f1e9-1f1ec", "html": "&#127465;&#127468;", "category": "f", "order": "2246"},
-		{"emoji": "🇩🇯", "name": "Djibouti", "shortname": ":flag-dj:", "unicode": "1f1e9-1f1ef", "html": "&#127465;&#127471;", "category": "f", "order": "2247"},
-		{"emoji": "🇩🇰", "name": "Denmark", "shortname": ":flag-dk:", "unicode": "1f1e9-1f1f0", "html": "&#127465;&#127472;", "category": "f", "order": "2248"},
-		{"emoji": "🇩🇲", "name": "Dominica", "shortname": ":flag-dm:", "unicode": "1f1e9-1f1f2", "html": "&#127465;&#127474;", "category": "f", "order": "2249"},
-		{"emoji": "🇩🇴", "name": "Dominican Republic", "shortname": ":flag-do:", "unicode": "1f1e9-1f1f4", "html": "&#127465;&#127476;", "category": "f", "order": "2250"},
-		{"emoji": "🇩🇿", "name": "Algeria", "shortname": ":flag-dz:", "unicode": "1f1e9-1f1ff", "html": "&#127465;&#127487;", "category": "f", "order": "2251"},
-		{"emoji": "🇪🇦", "name": "Ceuta and Melilla", "shortname": ":flag-ea:", "unicode": "1f1ea-1f1e6", "html": "&#127466;&#127462;", "category": "f", "order": "2252"},
-		{"emoji": "🇪🇨", "name": "Ecuador", "shortname": ":flag-ec:", "unicode": "1f1ea-1f1e8", "html": "&#127466;&#127464;", "category": "f", "order": "2253"},
-		{"emoji": "🇪🇪", "name": "Estonia", "shortname": ":flag-ee:", "unicode": "1f1ea-1f1ea", "html": "&#127466;&#127466;", "category": "f", "order": "2254"},
-		{"emoji": "🇪🇬", "name": "Egypt", "shortname": ":flag-eg:", "unicode": "1f1ea-1f1ec", "html": "&#127466;&#127468;", "category": "f", "order": "2255"},
-		{"emoji": "🇪🇭", "name": "Western Sahara", "shortname": ":flag-eh:", "unicode": "1f1ea-1f1ed", "html": "&#127466;&#127469;", "category": "f", "order": "2256"},
-		{"emoji": "🇪🇷", "name": "Eritrea", "shortname": ":flag-er:", "unicode": "1f1ea-1f1f7", "html": "&#127466;&#127479;", "category": "f", "order": "2257"},
-		{"emoji": "🇪🇸", "name": "Spain", "shortname": ":flag-es:", "unicode": "1f1ea-1f1f8", "html": "&#127466;&#127480;", "category": "f", "order": "2258"},
-		{"emoji": "🇪🇹", "name": "Ethiopia", "shortname": ":flag-et:", "unicode": "1f1ea-1f1f9", "html": "&#127466;&#127481;", "category": "f", "order": "2259"},
-		{"emoji": "🇪🇺", "name": "European Union", "shortname": ":flag-eu:", "unicode": "1f1ea-1f1fa", "html": "&#127466;&#127482;", "category": "f", "order": "2260"},
-		{"emoji": "🇫🇮", "name": "Finland", "shortname": ":flag-fi:", "unicode": "1f1eb-1f1ee", "html": "&#127467;&#127470;", "category": "f", "order": "2261"},
-		{"emoji": "🇫🇯", "name": "Fiji", "shortname": ":flag-fj:", "unicode": "1f1eb-1f1ef", "html": "&#127467;&#127471;", "category": "f", "order": "2262"},
-		{"emoji": "🇫🇰", "name": "Falkland Islands", "shortname": ":flag-fk:", "unicode": "1f1eb-1f1f0", "html": "&#127467;&#127472;", "category": "f", "order": "2263"},
-		{"emoji": "🇫🇲", "name": "Micronesia", "shortname": ":flag-fm:", "unicode": "1f1eb-1f1f2", "html": "&#127467;&#127474;", "category": "f", "order": "2264"},
-		{"emoji": "🇫🇴", "name": "Faroe Islands", "shortname": ":flag-fo:", "unicode": "1f1eb-1f1f4", "html": "&#127467;&#127476;", "category": "f", "order": "2265"},
-		{"emoji": "🇫🇷", "name": "France", "shortname": ":flag-fr:", "unicode": "1f1eb-1f1f7", "html": "&#127467;&#127479;", "category": "f", "order": "2266"},
-		{"emoji": "🇬🇦", "name": "Gabon", "shortname": ":flag-ga:", "unicode": "1f1ec-1f1e6", "html": "&#127468;&#127462;", "category": "f", "order": "2267"},
-		{"emoji": "🇬🇧", "name": "United Kingdom", "shortname": ":flag-gb:", "unicode": "1f1ec-1f1e7", "html": "&#127468;&#127463;", "category": "f", "order": "2268"},
-		{"emoji": "🇬🇩", "name": "Grenada", "shortname": ":flag-gd:", "unicode": "1f1ec-1f1e9", "html": "&#127468;&#127465;", "category": "f", "order": "2269"},
-		{"emoji": "🇬🇪", "name": "Georgia", "shortname": ":flag-ge:", "unicode": "1f1ec-1f1ea", "html": "&#127468;&#127466;", "category": "f", "order": "2270"},
-		{"emoji": "🇬🇫", "name": "French Guiana", "shortname": ":flag-gf:", "unicode": "1f1ec-1f1eb", "html": "&#127468;&#127467;", "category": "f", "order": "2271"},
-		{"emoji": "🇬🇬", "name": "Guernsey", "shortname": ":flag-gg:", "unicode": "1f1ec-1f1ec", "html": "&#127468;&#127468;", "category": "f", "order": "2272"},
-		{"emoji": "🇬🇭", "name": "Ghana", "shortname": ":flag-gh:", "unicode": "1f1ec-1f1ed", "html": "&#127468;&#127469;", "category": "f", "order": "2273"},
-		{"emoji": "🇬🇮", "name": "Gibraltar", "shortname": ":flag-gi:", "unicode": "1f1ec-1f1ee", "html": "&#127468;&#127470;", "category": "f", "order": "2274"},
-		{"emoji": "🇬🇱", "name": "Greenland", "shortname": ":flag-gl:", "unicode": "1f1ec-1f1f1", "html": "&#127468;&#127473;", "category": "f", "order": "2275"},
-		{"emoji": "🇬🇲", "name": "Gambia", "shortname": ":flag-gm:", "unicode": "1f1ec-1f1f2", "html": "&#127468;&#127474;", "category": "f", "order": "2276"},
-		{"emoji": "🇬🇳", "name": "Guinea", "shortname": ":flag-gn:", "unicode": "1f1ec-1f1f3", "html": "&#127468;&#127475;", "category": "f", "order": "2277"},
-		{"emoji": "🇬🇵", "name": "Guadeloupe", "shortname": ":flag-gp:", "unicode": "1f1ec-1f1f5", "html": "&#127468;&#127477;", "category": "f", "order": "2278"},
-		{"emoji": "🇬🇶", "name": "Equatorial Guinea", "shortname": ":flag-gq:", "unicode": "1f1ec-1f1f6", "html": "&#127468;&#127478;", "category": "f", "order": "2279"},
-		{"emoji": "🇬🇷", "name": "Greece", "shortname": ":flag-gr:", "unicode": "1f1ec-1f1f7", "html": "&#127468;&#127479;", "category": "f", "order": "2280"},
-		{"emoji": "🇬🇸", "name": "South Georgia and South Sandwich Islands", "shortname": ":flag-gs:", "unicode": "1f1ec-1f1f8", "html": "&#127468;&#127480;", "category": "f", "order": "2281"},
-		{"emoji": "🇬🇹", "name": "Guatemala", "shortname": ":flag-gt:", "unicode": "1f1ec-1f1f9", "html": "&#127468;&#127481;", "category": "f", "order": "2282"},
-		{"emoji": "🇬🇺", "name": "Guam", "shortname": ":flag-gu:", "unicode": "1f1ec-1f1fa", "html": "&#127468;&#127482;", "category": "f", "order": "2283"},
-		{"emoji": "🇬🇼", "name": "Guinea-Bissau", "shortname": ":flag-gw:", "unicode": "1f1ec-1f1fc", "html": "&#127468;&#127484;", "category": "f", "order": "2284"},
-		{"emoji": "🇬🇾", "name": "Guyana", "shortname": ":flag-gy:", "unicode": "1f1ec-1f1fe", "html": "&#127468;&#127486;", "category": "f", "order": "2285"},
-		{"emoji": "🇭🇰", "name": "Hong Kong SAR China", "shortname": ":flag-hk:", "unicode": "1f1ed-1f1f0", "html": "&#127469;&#127472;", "category": "f", "order": "2286"},
-		{"emoji": "🇭🇲", "name": "Heard and McDonald Islands", "shortname": ":flag-hm:", "unicode": "1f1ed-1f1f2", "html": "&#127469;&#127474;", "category": "f", "order": "2287"},
-		{"emoji": "🇭🇳", "name": "Honduras", "shortname": ":flag-hn:", "unicode": "1f1ed-1f1f3", "html": "&#127469;&#127475;", "category": "f", "order": "2288"},
-		{"emoji": "🇭🇷", "name": "Croatia", "shortname": ":flag-hr:", "unicode": "1f1ed-1f1f7", "html": "&#127469;&#127479;", "category": "f", "order": "2289"},
-		{"emoji": "🇭🇹", "name": "Haiti", "shortname": ":flag-ht:", "unicode": "1f1ed-1f1f9", "html": "&#127469;&#127481;", "category": "f", "order": "2290"},
-		{"emoji": "🇭🇺", "name": "Hungary", "shortname": ":flag-hu:", "unicode": "1f1ed-1f1fa", "html": "&#127469;&#127482;", "category": "f", "order": "2291"},
-		{"emoji": "🇮🇨", "name": "Canary Islands", "shortname": ":flag-ic:", "unicode": "1f1ee-1f1e8", "html": "&#127470;&#127464;", "category": "f", "order": "2292"},
-		{"emoji": "🇮🇩", "name": "Indonesia", "shortname": ":flag-id:", "unicode": "1f1ee-1f1e9", "html": "&#127470;&#127465;", "category": "f", "order": "2293"},
-		{"emoji": "🇮🇪", "name": "Ireland", "shortname": ":flag-ie:", "unicode": "1f1ee-1f1ea", "html": "&#127470;&#127466;", "category": "f", "order": "2294"},
-		{"emoji": "🇮🇱", "name": "Israel", "shortname": ":flag-il:", "unicode": "1f1ee-1f1f1", "html": "&#127470;&#127473;", "category": "f", "order": "2295"},
-		{"emoji": "🇮🇲", "name": "Isle of Man", "shortname": ":flag-im:", "unicode": "1f1ee-1f1f2", "html": "&#127470;&#127474;", "category": "f", "order": "2296"},
-		{"emoji": "🇮🇳", "name": "India", "shortname": ":flag-in:", "unicode": "1f1ee-1f1f3", "html": "&#127470;&#127475;", "category": "f", "order": "2297"},
-		{"emoji": "🇮🇴", "name": "British Indian Ocean Territory", "shortname": ":flag-io:", "unicode": "1f1ee-1f1f4", "html": "&#127470;&#127476;", "category": "f", "order": "2298"},
-		{"emoji": "🇮🇶", "name": "Iraq", "shortname": ":flag-iq:", "unicode": "1f1ee-1f1f6", "html": "&#127470;&#127478;", "category": "f", "order": "2299"},
-		{"emoji": "🇮🇷", "name": "Iran", "shortname": ":flag-ir:", "unicode": "1f1ee-1f1f7", "html": "&#127470;&#127479;", "category": "f", "order": "2300"},
-		{"emoji": "🇮🇸", "name": "Iceland", "shortname": ":flag-is:", "unicode": "1f1ee-1f1f8", "html": "&#127470;&#127480;", "category": "f", "order": "2301"},
-		{"emoji": "🇮🇹", "name": "Italy", "shortname": ":flag-it:", "unicode": "1f1ee-1f1f9", "html": "&#127470;&#127481;", "category": "f", "order": "2302"},
-		{"emoji": "🇯🇪", "name": "Jersey", "shortname": ":flag-je:", "unicode": "1f1ef-1f1ea", "html": "&#127471;&#127466;", "category": "f", "order": "2303"},
-		{"emoji": "🇯🇲", "name": "Jamaica", "shortname": ":flag-jm:", "unicode": "1f1ef-1f1f2", "html": "&#127471;&#127474;", "category": "f", "order": "2304"},
-		{"emoji": "🇯🇴", "name": "Jordan", "shortname": ":flag-jo:", "unicode": "1f1ef-1f1f4", "html": "&#127471;&#127476;", "category": "f", "order": "2305"},
-		{"emoji": "🇯🇵", "name": "Japan", "shortname": ":flag-jp:", "unicode": "1f1ef-1f1f5", "html": "&#127471;&#127477;", "category": "f", "order": "2306"},
-		{"emoji": "🇰🇪", "name": "Kenya", "shortname": ":flag-ke:", "unicode": "1f1f0-1f1ea", "html": "&#127472;&#127466;", "category": "f", "order": "2307"},
-		{"emoji": "🇰🇬", "name": "Kyrgyzstan", "shortname": ":flag-kg:", "unicode": "1f1f0-1f1ec", "html": "&#127472;&#127468;", "category": "f", "order": "2308"},
-		{"emoji": "🇰🇭", "name": "Cambodia", "shortname": ":flag-kh:", "unicode": "1f1f0-1f1ed", "html": "&#127472;&#127469;", "category": "f", "order": "2309"},
-		{"emoji": "🇰🇮", "name": "Kiribati", "shortname": ":flag-ki:", "unicode": "1f1f0-1f1ee", "html": "&#127472;&#127470;", "category": "f", "order": "2310"},
-		{"emoji": "🇰🇲", "name": "Comoros", "shortname": ":flag-km:", "unicode": "1f1f0-1f1f2", "html": "&#127472;&#127474;", "category": "f", "order": "2311"},
-		{"emoji": "🇰🇳", "name": "St. Kitts and Nevis", "shortname": ":flag-kn:", "unicode": "1f1f0-1f1f3", "html": "&#127472;&#127475;", "category": "f", "order": "2312"},
-		{"emoji": "🇰🇵", "name": "North Korea", "shortname": ":flag-kp:", "unicode": "1f1f0-1f1f5", "html": "&#127472;&#127477;", "category": "f", "order": "2313"},
-		{"emoji": "🇰🇷", "name": "South Korea", "shortname": ":flag-kr:", "unicode": "1f1f0-1f1f7", "html": "&#127472;&#127479;", "category": "f", "order": "2314"},
-		{"emoji": "🇰🇼", "name": "Kuwait", "shortname": ":flag-kw:", "unicode": "1f1f0-1f1fc", "html": "&#127472;&#127484;", "category": "f", "order": "2315"},
-		{"emoji": "🇰🇾", "name": "Cayman Islands", "shortname": ":flag-ky:", "unicode": "1f1f0-1f1fe", "html": "&#127472;&#127486;", "category": "f", "order": "2316"},
-		{"emoji": "🇰🇿", "name": "Kazakhstan", "shortname": ":flag-kz:", "unicode": "1f1f0-1f1ff", "html": "&#127472;&#127487;", "category": "f", "order": "2317"},
-		{"emoji": "🇱🇦", "name": "Laos", "shortname": ":flag-la:", "unicode": "1f1f1-1f1e6", "html": "&#127473;&#127462;", "category": "f", "order": "2318"},
-		{"emoji": "🇱🇧", "name": "Lebanon", "shortname": ":flag-lb:", "unicode": "1f1f1-1f1e7", "html": "&#127473;&#127463;", "category": "f", "order": "2319"},
-		{"emoji": "🇱🇨", "name": "St. Lucia", "shortname": ":flag-lc:", "unicode": "1f1f1-1f1e8", "html": "&#127473;&#127464;", "category": "f", "order": "2320"},
-		{"emoji": "🇱🇮", "name": "Liechtenstein", "shortname": ":flag-li:", "unicode": "1f1f1-1f1ee", "html": "&#127473;&#127470;", "category": "f", "order": "2321"},
-		{"emoji": "🇱🇰", "name": "Sri Lanka", "shortname": ":flag-lk:", "unicode": "1f1f1-1f1f0", "html": "&#127473;&#127472;", "category": "f", "order": "2322"},
-		{"emoji": "🇱🇷", "name": "Liberia", "shortname": ":flag-lr:", "unicode": "1f1f1-1f1f7", "html": "&#127473;&#127479;", "category": "f", "order": "2323"},
-		{"emoji": "🇱🇸", "name": "Lesotho", "shortname": ":flag-ls:", "unicode": "1f1f1-1f1f8", "html": "&#127473;&#127480;", "category": "f", "order": "2324"},
-		{"emoji": "🇱🇹", "name": "Lithuania", "shortname": ":flag-lt:", "unicode": "1f1f1-1f1f9", "html": "&#127473;&#127481;", "category": "f", "order": "2325"},
-		{"emoji": "🇱🇺", "name": "Luxembourg", "shortname": ":flag-lu:", "unicode": "1f1f1-1f1fa", "html": "&#127473;&#127482;", "category": "f", "order": "2326"},
-		{"emoji": "🇱🇻", "name": "Latvia", "shortname": ":flag-lv:", "unicode": "1f1f1-1f1fb", "html": "&#127473;&#127483;", "category": "f", "order": "2327"},
-		{"emoji": "🇱🇾", "name": "Libya", "shortname": ":flag-ly:", "unicode": "1f1f1-1f1fe", "html": "&#127473;&#127486;", "category": "f", "order": "2328"},
-		{"emoji": "🇲🇦", "name": "Morocco", "shortname": ":flag-ma:", "unicode": "1f1f2-1f1e6", "html": "&#127474;&#127462;", "category": "f", "order": "2329"},
-		{"emoji": "🇲🇨", "name": "Monaco", "shortname": ":flag-mc:", "unicode": "1f1f2-1f1e8", "html": "&#127474;&#127464;", "category": "f", "order": "2330"},
-		{"emoji": "🇲🇩", "name": "Moldova", "shortname": ":flag-md:", "unicode": "1f1f2-1f1e9", "html": "&#127474;&#127465;", "category": "f", "order": "2331"},
-		{"emoji": "🇲🇪", "name": "Montenegro", "shortname": ":flag-me:", "unicode": "1f1f2-1f1ea", "html": "&#127474;&#127466;", "category": "f", "order": "2332"},
-		{"emoji": "🇲🇫", "name": "St. Martin", "shortname": ":flag-mf:", "unicode": "1f1f2-1f1eb", "html": "&#127474;&#127467;", "category": "f", "order": "2333"},
-		{"emoji": "🇲🇬", "name": "Madagascar", "shortname": ":flag-mg:", "unicode": "1f1f2-1f1ec", "html": "&#127474;&#127468;", "category": "f", "order": "2334"},
-		{"emoji": "🇲🇭", "name": "Marshall Islands", "shortname": ":flag-mh:", "unicode": "1f1f2-1f1ed", "html": "&#127474;&#127469;", "category": "f", "order": "2335"},
-		{"emoji": "🇲🇰", "name": "Macedonia", "shortname": ":flag-mk:", "unicode": "1f1f2-1f1f0", "html": "&#127474;&#127472;", "category": "f", "order": "2336"},
-		{"emoji": "🇲🇱", "name": "Mali", "shortname": ":flag-ml:", "unicode": "1f1f2-1f1f1", "html": "&#127474;&#127473;", "category": "f", "order": "2337"},
-		{"emoji": "🇲🇲", "name": "Myanmar (Burma)", "shortname": ":flag-mm:", "unicode": "1f1f2-1f1f2", "html": "&#127474;&#127474;", "category": "f", "order": "2338"},
-		{"emoji": "🇲🇳", "name": "Mongolia", "shortname": ":flag-mn:", "unicode": "1f1f2-1f1f3", "html": "&#127474;&#127475;", "category": "f", "order": "2339"},
-		{"emoji": "🇲🇴", "name": "Macau SAR China", "shortname": ":flag-mo:", "unicode": "1f1f2-1f1f4", "html": "&#127474;&#127476;", "category": "f", "order": "2340"},
-		{"emoji": "🇲🇵", "name": "Northern Mariana Islands", "shortname": ":flag-mp:", "unicode": "1f1f2-1f1f5", "html": "&#127474;&#127477;", "category": "f", "order": "2341"},
-		{"emoji": "🇲🇶", "name": "Martinique", "shortname": ":flag-mq:", "unicode": "1f1f2-1f1f6", "html": "&#127474;&#127478;", "category": "f", "order": "2342"},
-		{"emoji": "🇲🇷", "name": "Mauritania", "shortname": ":flag-mr:", "unicode": "1f1f2-1f1f7", "html": "&#127474;&#127479;", "category": "f", "order": "2343"},
-		{"emoji": "🇲🇸", "name": "Montserrat", "shortname": ":flag-ms:", "unicode": "1f1f2-1f1f8", "html": "&#127474;&#127480;", "category": "f", "order": "2344"},
-		{"emoji": "🇲🇹", "name": "Malta", "shortname": ":flag-mt:", "unicode": "1f1f2-1f1f9", "html": "&#127474;&#127481;", "category": "f", "order": "2345"},
-		{"emoji": "🇲🇺", "name": "Mauritius", "shortname": ":flag-mu:", "unicode": "1f1f2-1f1fa", "html": "&#127474;&#127482;", "category": "f", "order": "2346"},
-		{"emoji": "🇲🇻", "name": "Maldives", "shortname": ":flag-mv:", "unicode": "1f1f2-1f1fb", "html": "&#127474;&#127483;", "category": "f", "order": "2347"},
-		{"emoji": "🇲🇼", "name": "Malawi", "shortname": ":flag-mw:", "unicode": "1f1f2-1f1fc", "html": "&#127474;&#127484;", "category": "f", "order": "2348"},
-		{"emoji": "🇲🇽", "name": "Mexico", "shortname": ":flag-mx:", "unicode": "1f1f2-1f1fd", "html": "&#127474;&#127485;", "category": "f", "order": "2349"},
-		{"emoji": "🇲🇾", "name": "Malaysia", "shortname": ":flag-my:", "unicode": "1f1f2-1f1fe", "html": "&#127474;&#127486;", "category": "f", "order": "2350"},
-		{"emoji": "🇲🇿", "name": "Mozambique", "shortname": ":flag-mz:", "unicode": "1f1f2-1f1ff", "html": "&#127474;&#127487;", "category": "f", "order": "2351"},
-		{"emoji": "🇳🇦", "name": "Namibia", "shortname": ":flag-na:", "unicode": "1f1f3-1f1e6", "html": "&#127475;&#127462;", "category": "f", "order": "2352"},
-		{"emoji": "🇳🇨", "name": "New Caledonia", "shortname": ":flag-nc:", "unicode": "1f1f3-1f1e8", "html": "&#127475;&#127464;", "category": "f", "order": "2353"},
-		{"emoji": "🇳🇪", "name": "Niger", "shortname": ":flag-ne:", "unicode": "1f1f3-1f1ea", "html": "&#127475;&#127466;", "category": "f", "order": "2354"},
-		{"emoji": "🇳🇫", "name": "Norfolk Island", "shortname": ":flag-nf:", "unicode": "1f1f3-1f1eb", "html": "&#127475;&#127467;", "category": "f", "order": "2355"},
-		{"emoji": "🇳🇬", "name": "Nigeria", "shortname": ":flag-ng:", "unicode": "1f1f3-1f1ec", "html": "&#127475;&#127468;", "category": "f", "order": "2356"},
-		{"emoji": "🇳🇮", "name": "Nicaragua", "shortname": ":flag-ni:", "unicode": "1f1f3-1f1ee", "html": "&#127475;&#127470;", "category": "f", "order": "2357"},
-		{"emoji": "🇳🇱", "name": "Netherlands", "shortname": ":flag-nl:", "unicode": "1f1f3-1f1f1", "html": "&#127475;&#127473;", "category": "f", "order": "2358"},
-		{"emoji": "🇳🇴", "name": "Norway", "shortname": ":flag-no:", "unicode": "1f1f3-1f1f4", "html": "&#127475;&#127476;", "category": "f", "order": "2359"},
-		{"emoji": "🇳🇵", "name": "Nepal", "shortname": ":flag-np:", "unicode": "1f1f3-1f1f5", "html": "&#127475;&#127477;", "category": "f", "order": "2360"},
-		{"emoji": "🇳🇷", "name": "Nauru", "shortname": ":flag-nr:", "unicode": "1f1f3-1f1f7", "html": "&#127475;&#127479;", "category": "f", "order": "2361"},
-		{"emoji": "🇳🇺", "name": "Niue", "shortname": ":flag-nu:", "unicode": "1f1f3-1f1fa", "html": "&#127475;&#127482;", "category": "f", "order": "2362"},
-		{"emoji": "🇳🇿", "name": "New Zealand", "shortname": ":flag-nz:", "unicode": "1f1f3-1f1ff", "html": "&#127475;&#127487;", "category": "f", "order": "2363"},
-		{"emoji": "🇴🇲", "name": "Oman", "shortname": ":flag-om:", "unicode": "1f1f4-1f1f2", "html": "&#127476;&#127474;", "category": "f", "order": "2364"},
-		{"emoji": "🇵🇦", "name": "Panama", "shortname": ":flag-pa:", "unicode": "1f1f5-1f1e6", "html": "&#127477;&#127462;", "category": "f", "order": "2365"},
-		{"emoji": "🇵🇪", "name": "Peru", "shortname": ":flag-pe:", "unicode": "1f1f5-1f1ea", "html": "&#127477;&#127466;", "category": "f", "order": "2366"},
-		{"emoji": "🇵🇫", "name": "French Polynesia", "shortname": ":flag-pf:", "unicode": "1f1f5-1f1eb", "html": "&#127477;&#127467;", "category": "f", "order": "2367"},
-		{"emoji": "🇵🇬", "name": "Papua New Guinea", "shortname": ":flag-pg:", "unicode": "1f1f5-1f1ec", "html": "&#127477;&#127468;", "category": "f", "order": "2368"},
-		{"emoji": "🇵🇭", "name": "Philippines", "shortname": ":flag-ph:", "unicode": "1f1f5-1f1ed", "html": "&#127477;&#127469;", "category": "f", "order": "2369"},
-		{"emoji": "🇵🇰", "name": "Pakistan", "shortname": ":flag-pk:", "unicode": "1f1f5-1f1f0", "html": "&#127477;&#127472;", "category": "f", "order": "2370"},
-		{"emoji": "🇵🇱", "name": "Poland", "shortname": ":flag-pl:", "unicode": "1f1f5-1f1f1", "html": "&#127477;&#127473;", "category": "f", "order": "2371"},
-		{"emoji": "🇵🇲", "name": "St. Pierre and Miquelon", "shortname": ":flag-pm:", "unicode": "1f1f5-1f1f2", "html": "&#127477;&#127474;", "category": "f", "order": "2372"},
-		{"emoji": "🇵🇳", "name": "Pitcairn Islands", "shortname": ":flag-pn:", "unicode": "1f1f5-1f1f3", "html": "&#127477;&#127475;", "category": "f", "order": "2373"},
-		{"emoji": "🇵🇷", "name": "Puerto Rico", "shortname": ":flag-pr:", "unicode": "1f1f5-1f1f7", "html": "&#127477;&#127479;", "category": "f", "order": "2374"},
-		{"emoji": "🇵🇸", "name": "Palestinian Territories", "shortname": ":flag-ps:", "unicode": "1f1f5-1f1f8", "html": "&#127477;&#127480;", "category": "f", "order": "2375"},
-		{"emoji": "🇵🇹", "name": "Portugal", "shortname": ":flag-pt:", "unicode": "1f1f5-1f1f9", "html": "&#127477;&#127481;", "category": "f", "order": "2376"},
-		{"emoji": "🇵🇼", "name": "Palau", "shortname": ":flag-pw:", "unicode": "1f1f5-1f1fc", "html": "&#127477;&#127484;", "category": "f", "order": "2377"},
-		{"emoji": "🇵🇾", "name": "Paraguay", "shortname": ":flag-py:", "unicode": "1f1f5-1f1fe", "html": "&#127477;&#127486;", "category": "f", "order": "2378"},
-		{"emoji": "🇶🇦", "name": "Qatar", "shortname": ":flag-qa:", "unicode": "1f1f6-1f1e6", "html": "&#127478;&#127462;", "category": "f", "order": "2379"},
-		{"emoji": "🇷🇪", "name": "Réunion", "shortname": ":flag-re:", "unicode": "1f1f7-1f1ea", "html": "&#127479;&#127466;", "category": "f", "order": "2380"},
-		{"emoji": "🇷🇴", "name": "Romania", "shortname": ":flag-ro:", "unicode": "1f1f7-1f1f4", "html": "&#127479;&#127476;", "category": "f", "order": "2381"},
-		{"emoji": "🇷🇸", "name": "Serbia", "shortname": ":flag-rs:", "unicode": "1f1f7-1f1f8", "html": "&#127479;&#127480;", "category": "f", "order": "2382"},
-		{"emoji": "🇷🇺", "name": "Russia", "shortname": ":flag-ru:", "unicode": "1f1f7-1f1fa", "html": "&#127479;&#127482;", "category": "f", "order": "2383"},
-		{"emoji": "🇷🇼", "name": "Rwanda", "shortname": ":flag-rw:", "unicode": "1f1f7-1f1fc", "html": "&#127479;&#127484;", "category": "f", "order": "2384"},
-		{"emoji": "🇸🇦", "name": "Saudi Arabia", "shortname": ":flag-sa:", "unicode": "1f1f8-1f1e6", "html": "&#127480;&#127462;", "category": "f", "order": "2385"},
-		{"emoji": "🇸🇧", "name": "Solomon Islands", "shortname": ":flag-sb:", "unicode": "1f1f8-1f1e7", "html": "&#127480;&#127463;", "category": "f", "order": "2386"},
-		{"emoji": "🇸🇨", "name": "Seychelles", "shortname": ":flag-sc:", "unicode": "1f1f8-1f1e8", "html": "&#127480;&#127464;", "category": "f", "order": "2387"},
-		{"emoji": "🇸🇩", "name": "Sudan", "shortname": ":flag-sd:", "unicode": "1f1f8-1f1e9", "html": "&#127480;&#127465;", "category": "f", "order": "2388"},
-		{"emoji": "🇸🇪", "name": "Sweden", "shortname": ":flag-se:", "unicode": "1f1f8-1f1ea", "html": "&#127480;&#127466;", "category": "f", "order": "2389"},
-		{"emoji": "🇸🇬", "name": "Singapore", "shortname": ":flag-sg:", "unicode": "1f1f8-1f1ec", "html": "&#127480;&#127468;", "category": "f", "order": "2390"},
-		{"emoji": "🇸🇭", "name": "St. Helena", "shortname": ":flag-sh:", "unicode": "1f1f8-1f1ed", "html": "&#127480;&#127469;", "category": "f", "order": "2391"},
-		{"emoji": "🇸🇮", "name": "Slovenia", "shortname": ":flag-si:", "unicode": "1f1f8-1f1ee", "html": "&#127480;&#127470;", "category": "f", "order": "2392"},
-		{"emoji": "🇸🇯", "name": "Svalbard and Jan Mayen", "shortname": ":flag-sj:", "unicode": "1f1f8-1f1ef", "html": "&#127480;&#127471;", "category": "f", "order": "2393"},
-		{"emoji": "🇸🇰", "name": "Slovakia", "shortname": ":flag-sk:", "unicode": "1f1f8-1f1f0", "html": "&#127480;&#127472;", "category": "f", "order": "2394"},
-		{"emoji": "🇸🇱", "name": "Sierra Leone", "shortname": ":flag-sl:", "unicode": "1f1f8-1f1f1", "html": "&#127480;&#127473;", "category": "f", "order": "2395"},
-		{"emoji": "🇸🇲", "name": "San Marino", "shortname": ":flag-sm:", "unicode": "1f1f8-1f1f2", "html": "&#127480;&#127474;", "category": "f", "order": "2396"},
-		{"emoji": "🇸🇳", "name": "Senegal", "shortname": ":flag-sn:", "unicode": "1f1f8-1f1f3", "html": "&#127480;&#127475;", "category": "f", "order": "2397"},
-		{"emoji": "🇸🇴", "name": "Somalia", "shortname": ":flag-so:", "unicode": "1f1f8-1f1f4", "html": "&#127480;&#127476;", "category": "f", "order": "2398"},
-		{"emoji": "🇸🇷", "name": "Suriname", "shortname": ":flag-sr:", "unicode": "1f1f8-1f1f7", "html": "&#127480;&#127479;", "category": "f", "order": "2399"},
-		{"emoji": "🇸🇸", "name": "South Sudan", "shortname": ":flag-ss:", "unicode": "1f1f8-1f1f8", "html": "&#127480;&#127480;", "category": "f", "order": "2400"},
-		{"emoji": "🇸🇹", "name": "São Tomé and Prí­ncipe", "shortname": ":flag-st:", "unicode": "1f1f8-1f1f9", "html": "&#127480;&#127481;", "category": "f", "order": "2401"},
-		{"emoji": "🇸🇻", "name": "El Salvador", "shortname": ":flag-sv:", "unicode": "1f1f8-1f1fb", "html": "&#127480;&#127483;", "category": "f", "order": "2402"},
-		{"emoji": "🇸🇽", "name": "Sint Maarten", "shortname": ":flag-sx:", "unicode": "1f1f8-1f1fd", "html": "&#127480;&#127485;", "category": "f", "order": "2403"},
-		{"emoji": "🇸🇾", "name": "Syria", "shortname": ":flag-sy:", "unicode": "1f1f8-1f1fe", "html": "&#127480;&#127486;", "category": "f", "order": "2404"},
-		{"emoji": "🇸🇿", "name": "Swaziland", "shortname": ":flag-sz:", "unicode": "1f1f8-1f1ff", "html": "&#127480;&#127487;", "category": "f", "order": "2405"},
-		{"emoji": "🇹🇦", "name": "Tristan da Cunha", "shortname": ":flag-ta:", "unicode": "1f1f9-1f1e6", "html": "&#127481;&#127462;", "category": "f", "order": "2406"},
-		{"emoji": "🇹🇨", "name": "Turks and Caicos Islands", "shortname": ":flag-tc:", "unicode": "1f1f9-1f1e8", "html": "&#127481;&#127464;", "category": "f", "order": "2407"},
-		{"emoji": "🇹🇩", "name": "Chad", "shortname": ":flag-td:", "unicode": "1f1f9-1f1e9", "html": "&#127481;&#127465;", "category": "f", "order": "2408"},
-		{"emoji": "🇹🇫", "name": "French Southern Territories", "shortname": ":flag-tf:", "unicode": "1f1f9-1f1eb", "html": "&#127481;&#127467;", "category": "f", "order": "2409"},
-		{"emoji": "🇹🇬", "name": "Togo", "shortname": ":flag-tg:", "unicode": "1f1f9-1f1ec", "html": "&#127481;&#127468;", "category": "f", "order": "2410"},
-		{"emoji": "🇹🇭", "name": "Thailand", "shortname": ":flag-th:", "unicode": "1f1f9-1f1ed", "html": "&#127481;&#127469;", "category": "f", "order": "2411"},
-		{"emoji": "🇹🇯", "name": "Tajikistan", "shortname": ":flag-tj:", "unicode": "1f1f9-1f1ef", "html": "&#127481;&#127471;", "category": "f", "order": "2412"},
-		{"emoji": "🇹🇰", "name": "Tokelau", "shortname": ":flag-tk:", "unicode": "1f1f9-1f1f0", "html": "&#127481;&#127472;", "category": "f", "order": "2413"},
-		{"emoji": "🇹🇱", "name": "Timor-Leste", "shortname": ":flag-tl:", "unicode": "1f1f9-1f1f1", "html": "&#127481;&#127473;", "category": "f", "order": "2414"},
-		{"emoji": "🇹🇲", "name": "Turkmenistan", "shortname": ":flag-tm:", "unicode": "1f1f9-1f1f2", "html": "&#127481;&#127474;", "category": "f", "order": "2415"},
-		{"emoji": "🇹🇳", "name": "Tunisia", "shortname": ":flag-tn:", "unicode": "1f1f9-1f1f3", "html": "&#127481;&#127475;", "category": "f", "order": "2416"},
-		{"emoji": "🇹🇴", "name": "Tonga", "shortname": ":flag-to:", "unicode": "1f1f9-1f1f4", "html": "&#127481;&#127476;", "category": "f", "order": "2417"},
-		{"emoji": "🇹🇷", "name": "Turkey", "shortname": ":flag-tr:", "unicode": "1f1f9-1f1f7", "html": "&#127481;&#127479;", "category": "f", "order": "2418"},
-		{"emoji": "🇹🇹", "name": "Trinidad and Tobago", "shortname": ":flag-tt:", "unicode": "1f1f9-1f1f9", "html": "&#127481;&#127481;", "category": "f", "order": "2419"},
-		{"emoji": "🇹🇻", "name": "Tuvalu", "shortname": ":flag-tv:", "unicode": "1f1f9-1f1fb", "html": "&#127481;&#127483;", "category": "f", "order": "2420"},
-		{"emoji": "🇹🇼", "name": "Taiwan", "shortname": ":flag-tw:", "unicode": "1f1f9-1f1fc", "html": "&#127481;&#127484;", "category": "f", "order": "2421"},
-		{"emoji": "🇹🇿", "name": "Tanzania", "shortname": ":flag-tz:", "unicode": "1f1f9-1f1ff", "html": "&#127481;&#127487;", "category": "f", "order": "2422"},
-		{"emoji": "🇺🇦", "name": "Ukraine", "shortname": ":flag-ua:", "unicode": "1f1fa-1f1e6", "html": "&#127482;&#127462;", "category": "f", "order": "2423"},
-		{"emoji": "🇺🇬", "name": "Uganda", "shortname": ":flag-ug:", "unicode": "1f1fa-1f1ec", "html": "&#127482;&#127468;", "category": "f", "order": "2424"},
-		{"emoji": "🇺🇲", "name": "U.S. Outlying Islands", "shortname": ":flag-um:", "unicode": "1f1fa-1f1f2", "html": "&#127482;&#127474;", "category": "f", "order": "2425"},
-		{"emoji": "🇺🇸", "name": "United States", "shortname": ":flag-us:", "unicode": "1f1fa-1f1f8", "html": "&#127482;&#127480;", "category": "f", "order": "2427"},
-		{"emoji": "🇺🇾", "name": "Uruguay", "shortname": ":flag-uy:", "unicode": "1f1fa-1f1fe", "html": "&#127482;&#127486;", "category": "f", "order": "2428"},
-		{"emoji": "🇺🇿", "name": "Uzbekistan", "shortname": ":flag-uz:", "unicode": "1f1fa-1f1ff", "html": "&#127482;&#127487;", "category": "f", "order": "2429"},
-		{"emoji": "🇻🇦", "name": "Vatican City", "shortname": ":flag-va:", "unicode": "1f1fb-1f1e6", "html": "&#127483;&#127462;", "category": "f", "order": "2430"},
-		{"emoji": "🇻🇨", "name": "St. Vincent and Grenadines", "shortname": ":flag-vc:", "unicode": "1f1fb-1f1e8", "html": "&#127483;&#127464;", "category": "f", "order": "2431"},
-		{"emoji": "🇻🇪", "name": "Venezuela", "shortname": ":flag-ve:", "unicode": "1f1fb-1f1ea", "html": "&#127483;&#127466;", "category": "f", "order": "2432"},
-		{"emoji": "🇻🇬", "name": "British Virgin Islands", "shortname": ":flag-vg:", "unicode": "1f1fb-1f1ec", "html": "&#127483;&#127468;", "category": "f", "order": "2433"},
-		{"emoji": "🇻🇮", "name": "U.S. Virgin Islands", "shortname": ":flag-vi:", "unicode": "1f1fb-1f1ee", "html": "&#127483;&#127470;", "category": "f", "order": "2434"},
-		{"emoji": "🇻🇳", "name": "Vietnam", "shortname": ":flag-vn:", "unicode": "1f1fb-1f1f3", "html": "&#127483;&#127475;", "category": "f", "order": "2435"},
-		{"emoji": "🇻🇺", "name": "Vanuatu", "shortname": ":flag_vu:", "unicode": "1f1fb-1f1fa", "html": "&#127483;&#127482;", "category": "f", "order": "2436"},
-		{"emoji": "🇼🇫", "name": "Wallis and Futuna", "shortname": ":flag_wf:", "unicode": "1f1fc-1f1eb", "html": "&#127484;&#127467;", "category": "f", "order": "2437"},
-		{"emoji": "🇼🇸", "name": "Samoa", "shortname": ":flag_ws:", "unicode": "1f1fc-1f1f8", "html": "&#127484;&#127480;", "category": "f", "order": "2438"},
-		{"emoji": "🇽🇰", "name": "Kosovo", "shortname": ":flag_xk:", "unicode": "1f1fd-1f1f0", "html": "&#127485;&#127472;", "category": "f", "order": "2439"},
-		{"emoji": "🇾🇪", "name": "Yemen", "shortname": ":flag_ye:", "unicode": "1f1fe-1f1ea", "html": "&#127486;&#127466;", "category": "f", "order": "2440"},
-		{"emoji": "🇾🇹", "name": "Mayotte", "shortname": ":flag_yt:", "unicode": "1f1fe-1f1f9", "html": "&#127486;&#127481;", "category": "f", "order": "2441"},
-		{"emoji": "🇿🇦", "name": "South Africa", "shortname": ":flag_za:", "unicode": "1f1ff-1f1e6", "html": "&#127487;&#127462;", "category": "f", "order": "2442"},
-		{"emoji": "🇿🇲", "name": "Zambia", "shortname": ":flag_zm:", "unicode": "1f1ff-1f1f2", "html": "&#127487;&#127474;", "category": "f", "order": "2443"},
-		{"emoji": "🇿🇼", "name": "Zimbabwe", "shortname": ":flag_zw:", "unicode": "1f1ff-1f1fc", "html": "&#127487;&#127484;", "category": "f", "order": "2444"},
-		{"emoji": "🖤", "name": "black_heart", "shortname": ":black_heart:", "unicode": "1f5a4", "html": "&#128420;", "category": "s", "order": "1296"},
-		{"emoji": "🗨", "name": "speech_left", "shortname": ":speech_left:", "unicode": "1f5e8", "html": "&#128488;", "category": "s", "order": "1310"},
-		{"emoji": "🥚", "name": "egg", "shortname": ":egg:", "unicode": "1f95a", "html": "&#129370;", "category": "d", "order": "1489"},
-		{"emoji": "🛑", "name": "octagonal_sign", "shortname": ":octagonal_sign:", "unicode": "1f6d1", "html": "&#128721;", "category": "s", "order": "1641"},
-		{"emoji": "♠", "name": "spades", "shortname": ":spades:", "unicode": "2660", "html": "&spades;", "category": "s", "order": "1807"},
-		{"emoji": "♥", "name": "hearts", "shortname": ":hearts:", "unicode": "2665", "html": "&hearts;", "category": "s", "order": "1808"},
-		{"emoji": "♦", "name": "diamonds", "shortname": ":diamonds:", "unicode": "2666", "html": "&diams;", "category": "s", "order": "1809"},
-		{"emoji": "♣", "name": "clubs", "shortname": ":clubs:", "unicode": "2663", "html": "&clubs;", "category": "s", "order": "1810"},
-		{"emoji": "🥁", "name": "drum", "shortname": ":drum:", "unicode": "1f941", "html": "&#129345;", "category": "a", "order": "1837"},
-		{"emoji": "↔", "name": "left_right_arrow", "shortname": ":left_right_arrow:", "unicode": "2194", "html": "&harr;", "category": "s", "order": "2011"},
-		{"emoji": "©", "name": "copyright", "shortname": ":copyright:", "unicode": "00a9", "html": "&copy;", "category": "s", "order": "2103"},
-		{"emoji": "®", "name": "registered", "shortname": ":registered:", "unicode": "00ae", "html": "&reg;", "category": "s", "order": "2104"},
-		{"emoji": "™", "name": "tm", "shortname": ":tm:", "unicode": "2122", "html": "&trade;", "category": "s", "order": "2105"},
-		{"emoji": "0️⃣", "name": "0", "shortname": ":0:", "unicode": "", "html": "&#48;", "category": "", "order": ""},
-		{"emoji": "1️⃣", "name": "1", "shortname": ":1:", "unicode": "", "html": "&#49;", "category": "", "order": ""},
-		{"emoji": "2️⃣", "name": "2", "shortname": ":2:", "unicode": "", "html": "&#50;", "category": "", "order": ""},
-		{"emoji": "3️⃣", "name": "3", "shortname": ":3:", "unicode": "", "html": "&#51;", "category": "", "order": ""},
-		{"emoji": "4️⃣", "name": "4", "shortname": ":4:", "unicode": "", "html": "&#52;", "category": "", "order": ""},
-		{"emoji": "5️⃣", "name": "5", "shortname": ":5:", "unicode": "", "html": "&#53;", "category": "", "order": ""},
-		{"emoji": "6️⃣", "name": "6", "shortname": ":6:", "unicode": "", "html": "&#54;", "category": "", "order": ""},
-		{"emoji": "7️⃣", "name": "7", "shortname": ":7:", "unicode": "", "html": "&#55;", "category": "", "order": ""},
-		{"emoji": "8️⃣", "name": "8", "shortname": ":8:", "unicode": "", "html": "&#56;", "category": "", "order": ""},
-		{"emoji": "9️⃣", "name": "9", "shortname": ":9:", "unicode": "", "html": "&#57;", "category": "", "order": ""},
-		{"emoji": "#⃣", "name": "hash", "shortname": ":hash:", "unicode": "0023-20e3", "html": "#&#8419;", "category": "s", "order": "2106"},
-		{"emoji": "*⃣", "name": "asterisk", "shortname": ":asterisk:", "unicode": "002a-20e3", "html": "*&#8419;", "category": "s", "order": "2107"},
-		{"emoji": "0⃣", "name": "zero", "shortname": ":zero:", "unicode": "0030-20e3", "html": "0&#8419;", "category": "s", "order": "2108"},
-		{"emoji": "1⃣", "name": "one", "shortname": ":one:", "unicode": "0031-20e3", "html": "1&#8419;", "category": "s", "order": "2109"},
-		{"emoji": "2⃣", "name": "two", "shortname": ":two:", "unicode": "0032-20e3", "html": "2&#8419;", "category": "s", "order": "2110"},
-		{"emoji": "3⃣", "name": "three", "shortname": ":three:", "unicode": "0033-20e3", "html": "3&#8419;", "category": "s", "order": "2111"},
-		{"emoji": "4⃣", "name": "four", "shortname": ":four:", "unicode": "0034-20e3", "html": "4&#8419;", "category": "s", "order": "2112"},
-		{"emoji": "5⃣", "name": "five", "shortname": ":five:", "unicode": "0035-20e3", "html": "5&#8419;", "category": "s", "order": "2113"},
-		{"emoji": "6⃣", "name": "six", "shortname": ":six:", "unicode": "0036-20e3", "html": "6&#8419;", "category": "s", "order": "2114"},
-		{"emoji": "7⃣", "name": "seven", "shortname": ":seven:", "unicode": "0037-20e3", "html": "7&#8419;", "category": "s", "order": "2115"},
-		{"emoji": "8⃣", "name": "eight", "shortname": ":eight:", "unicode": "0038-20e3", "html": "8&#8419;", "category": "s", "order": "2116"},
-		{"emoji": "9⃣", "name": "nine", "shortname": ":nine:", "unicode": "0039-20e3", "html": "9&#8419;", "category": "s", "order": "2117"}
-	]
-}
+[
+  {
+    "emoji": "😀"
+  , "description": "grinning face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "grinning"
+    ]
+  , "tags": [
+      "smile"
+    , "happy"
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😃"
+  , "description": "grinning face with big eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "smiley"
+    ]
+  , "tags": [
+      "happy"
+    , "joy"
+    , "haha"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😄"
+  , "description": "grinning face with smiling eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "smile"
+    ]
+  , "tags": [
+      "happy"
+    , "joy"
+    , "laugh"
+    , "pleased"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😁"
+  , "description": "beaming face with smiling eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "grin"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😆"
+  , "description": "grinning squinting face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "laughing"
+    , "satisfied"
+    ]
+  , "tags": [
+      "happy"
+    , "haha"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😅"
+  , "description": "grinning face with sweat"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "sweat_smile"
+    ]
+  , "tags": [
+      "hot"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤣"
+  , "description": "rolling on the floor laughing"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "rofl"
+    ]
+  , "tags": [
+      "lol"
+    , "laughing"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "😂"
+  , "description": "face with tears of joy"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "joy"
+    ]
+  , "tags": [
+      "tears"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🙂"
+  , "description": "slightly smiling face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "slightly_smiling_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🙃"
+  , "description": "upside-down face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "upside_down_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "😉"
+  , "description": "winking face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "wink"
+    ]
+  , "tags": [
+      "flirt"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😊"
+  , "description": "smiling face with smiling eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "blush"
+    ]
+  , "tags": [
+      "proud"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😇"
+  , "description": "smiling face with halo"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "innocent"
+    ]
+  , "tags": [
+      "angel"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥰"
+  , "description": "smiling face with hearts"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "smiling_face_with_three_hearts"
+    ]
+  , "tags": [
+      "love"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "😍"
+  , "description": "smiling face with heart-eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "heart_eyes"
+    ]
+  , "tags": [
+      "love"
+    , "crush"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤩"
+  , "description": "star-struck"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "star_struck"
+    ]
+  , "tags": [
+      "eyes"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "😘"
+  , "description": "face blowing a kiss"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "kissing_heart"
+    ]
+  , "tags": [
+      "flirt"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😗"
+  , "description": "kissing face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "kissing"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "☺️"
+  , "description": "smiling face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "relaxed"
+    ]
+  , "tags": [
+      "blush"
+    , "pleased"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😚"
+  , "description": "kissing face with closed eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "kissing_closed_eyes"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😙"
+  , "description": "kissing face with smiling eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "kissing_smiling_eyes"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥲"
+  , "description": "smiling face with tear"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "smiling_face_with_tear"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "😋"
+  , "description": "face savoring food"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "yum"
+    ]
+  , "tags": [
+      "tongue"
+    , "lick"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😛"
+  , "description": "face with tongue"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "stuck_out_tongue"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😜"
+  , "description": "winking face with tongue"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "stuck_out_tongue_winking_eye"
+    ]
+  , "tags": [
+      "prank"
+    , "silly"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤪"
+  , "description": "zany face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "zany_face"
+    ]
+  , "tags": [
+      "goofy"
+    , "wacky"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "😝"
+  , "description": "squinting face with tongue"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "stuck_out_tongue_closed_eyes"
+    ]
+  , "tags": [
+      "prank"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤑"
+  , "description": "money-mouth face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "money_mouth_face"
+    ]
+  , "tags": [
+      "rich"
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🤗"
+  , "description": "hugging face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "hugs"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🤭"
+  , "description": "face with hand over mouth"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "hand_over_mouth"
+    ]
+  , "tags": [
+      "quiet"
+    , "whoops"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🤫"
+  , "description": "shushing face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "shushing_face"
+    ]
+  , "tags": [
+      "silence"
+    , "quiet"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🤔"
+  , "description": "thinking face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "thinking"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🤐"
+  , "description": "zipper-mouth face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "zipper_mouth_face"
+    ]
+  , "tags": [
+      "silence"
+    , "hush"
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🤨"
+  , "description": "face with raised eyebrow"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "raised_eyebrow"
+    ]
+  , "tags": [
+      "suspicious"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "😐"
+  , "description": "neutral face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "neutral_face"
+    ]
+  , "tags": [
+      "meh"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😑"
+  , "description": "expressionless face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "expressionless"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😶"
+  , "description": "face without mouth"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "no_mouth"
+    ]
+  , "tags": [
+      "mute"
+    , "silence"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😏"
+  , "description": "smirking face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "smirk"
+    ]
+  , "tags": [
+      "smug"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😒"
+  , "description": "unamused face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "unamused"
+    ]
+  , "tags": [
+      "meh"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🙄"
+  , "description": "face with rolling eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "roll_eyes"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "😬"
+  , "description": "grimacing face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "grimacing"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤥"
+  , "description": "lying face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "lying_face"
+    ]
+  , "tags": [
+      "liar"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "😌"
+  , "description": "relieved face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "relieved"
+    ]
+  , "tags": [
+      "whew"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😔"
+  , "description": "pensive face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "pensive"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😪"
+  , "description": "sleepy face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "sleepy"
+    ]
+  , "tags": [
+      "tired"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤤"
+  , "description": "drooling face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "drooling_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "😴"
+  , "description": "sleeping face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "sleeping"
+    ]
+  , "tags": [
+      "zzz"
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😷"
+  , "description": "face with medical mask"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "mask"
+    ]
+  , "tags": [
+      "sick"
+    , "ill"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤒"
+  , "description": "face with thermometer"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "face_with_thermometer"
+    ]
+  , "tags": [
+      "sick"
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🤕"
+  , "description": "face with head-bandage"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "face_with_head_bandage"
+    ]
+  , "tags": [
+      "hurt"
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🤢"
+  , "description": "nauseated face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "nauseated_face"
+    ]
+  , "tags": [
+      "sick"
+    , "barf"
+    , "disgusted"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🤮"
+  , "description": "face vomiting"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "vomiting_face"
+    ]
+  , "tags": [
+      "barf"
+    , "sick"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🤧"
+  , "description": "sneezing face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "sneezing_face"
+    ]
+  , "tags": [
+      "achoo"
+    , "sick"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥵"
+  , "description": "hot face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "hot_face"
+    ]
+  , "tags": [
+      "heat"
+    , "sweating"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥶"
+  , "description": "cold face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "cold_face"
+    ]
+  , "tags": [
+      "freezing"
+    , "ice"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥴"
+  , "description": "woozy face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "woozy_face"
+    ]
+  , "tags": [
+      "groggy"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "😵"
+  , "description": "dizzy face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "dizzy_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤯"
+  , "description": "exploding head"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "exploding_head"
+    ]
+  , "tags": [
+      "mind"
+    , "blown"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🤠"
+  , "description": "cowboy hat face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "cowboy_hat_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥳"
+  , "description": "partying face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "partying_face"
+    ]
+  , "tags": [
+      "celebration"
+    , "birthday"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥸"
+  , "description": "disguised face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "disguised_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "😎"
+  , "description": "smiling face with sunglasses"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "sunglasses"
+    ]
+  , "tags": [
+      "cool"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤓"
+  , "description": "nerd face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "nerd_face"
+    ]
+  , "tags": [
+      "geek"
+    , "glasses"
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🧐"
+  , "description": "face with monocle"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "monocle_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "😕"
+  , "description": "confused face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "confused"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😟"
+  , "description": "worried face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "worried"
+    ]
+  , "tags": [
+      "nervous"
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🙁"
+  , "description": "slightly frowning face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "slightly_frowning_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "☹️"
+  , "description": "frowning face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "frowning_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "😮"
+  , "description": "face with open mouth"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "open_mouth"
+    ]
+  , "tags": [
+      "surprise"
+    , "impressed"
+    , "wow"
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😯"
+  , "description": "hushed face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "hushed"
+    ]
+  , "tags": [
+      "silence"
+    , "speechless"
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😲"
+  , "description": "astonished face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "astonished"
+    ]
+  , "tags": [
+      "amazed"
+    , "gasp"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😳"
+  , "description": "flushed face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "flushed"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥺"
+  , "description": "pleading face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "pleading_face"
+    ]
+  , "tags": [
+      "puppy"
+    , "eyes"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "😦"
+  , "description": "frowning face with open mouth"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "frowning"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😧"
+  , "description": "anguished face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "anguished"
+    ]
+  , "tags": [
+      "stunned"
+    ]
+  , "unicode_version": "6.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😨"
+  , "description": "fearful face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "fearful"
+    ]
+  , "tags": [
+      "scared"
+    , "shocked"
+    , "oops"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😰"
+  , "description": "anxious face with sweat"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "cold_sweat"
+    ]
+  , "tags": [
+      "nervous"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😥"
+  , "description": "sad but relieved face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "disappointed_relieved"
+    ]
+  , "tags": [
+      "phew"
+    , "sweat"
+    , "nervous"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😢"
+  , "description": "crying face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "cry"
+    ]
+  , "tags": [
+      "sad"
+    , "tear"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😭"
+  , "description": "loudly crying face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "sob"
+    ]
+  , "tags": [
+      "sad"
+    , "cry"
+    , "bawling"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😱"
+  , "description": "face screaming in fear"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "scream"
+    ]
+  , "tags": [
+      "horror"
+    , "shocked"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😖"
+  , "description": "confounded face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "confounded"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😣"
+  , "description": "persevering face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "persevere"
+    ]
+  , "tags": [
+      "struggling"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😞"
+  , "description": "disappointed face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "disappointed"
+    ]
+  , "tags": [
+      "sad"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😓"
+  , "description": "downcast face with sweat"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "sweat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😩"
+  , "description": "weary face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "weary"
+    ]
+  , "tags": [
+      "tired"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😫"
+  , "description": "tired face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "tired_face"
+    ]
+  , "tags": [
+      "upset"
+    , "whine"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥱"
+  , "description": "yawning face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "yawning_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "😤"
+  , "description": "face with steam from nose"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "triumph"
+    ]
+  , "tags": [
+      "smug"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😡"
+  , "description": "pouting face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "rage"
+    , "pout"
+    ]
+  , "tags": [
+      "angry"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😠"
+  , "description": "angry face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "angry"
+    ]
+  , "tags": [
+      "mad"
+    , "annoyed"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤬"
+  , "description": "face with symbols on mouth"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "cursing_face"
+    ]
+  , "tags": [
+      "foul"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "😈"
+  , "description": "smiling face with horns"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "smiling_imp"
+    ]
+  , "tags": [
+      "devil"
+    , "evil"
+    , "horns"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👿"
+  , "description": "angry face with horns"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "imp"
+    ]
+  , "tags": [
+      "angry"
+    , "devil"
+    , "evil"
+    , "horns"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💀"
+  , "description": "skull"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "skull"
+    ]
+  , "tags": [
+      "dead"
+    , "danger"
+    , "poison"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "☠️"
+  , "description": "skull and crossbones"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "skull_and_crossbones"
+    ]
+  , "tags": [
+      "danger"
+    , "pirate"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "💩"
+  , "description": "pile of poo"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "hankey"
+    , "poop"
+    , "shit"
+    ]
+  , "tags": [
+      "crap"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤡"
+  , "description": "clown face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "clown_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "👹"
+  , "description": "ogre"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "japanese_ogre"
+    ]
+  , "tags": [
+      "monster"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👺"
+  , "description": "goblin"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "japanese_goblin"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👻"
+  , "description": "ghost"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "ghost"
+    ]
+  , "tags": [
+      "halloween"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👽"
+  , "description": "alien"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "alien"
+    ]
+  , "tags": [
+      "ufo"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👾"
+  , "description": "alien monster"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "space_invader"
+    ]
+  , "tags": [
+      "game"
+    , "retro"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤖"
+  , "description": "robot"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "robot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "😺"
+  , "description": "grinning cat"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "smiley_cat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😸"
+  , "description": "grinning cat with smiling eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "smile_cat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😹"
+  , "description": "cat with tears of joy"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "joy_cat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😻"
+  , "description": "smiling cat with heart-eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "heart_eyes_cat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😼"
+  , "description": "cat with wry smile"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "smirk_cat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😽"
+  , "description": "kissing cat"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "kissing_cat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🙀"
+  , "description": "weary cat"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "scream_cat"
+    ]
+  , "tags": [
+      "horror"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😿"
+  , "description": "crying cat"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "crying_cat_face"
+    ]
+  , "tags": [
+      "sad"
+    , "tear"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "😾"
+  , "description": "pouting cat"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "pouting_cat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🙈"
+  , "description": "see-no-evil monkey"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "see_no_evil"
+    ]
+  , "tags": [
+      "monkey"
+    , "blind"
+    , "ignore"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🙉"
+  , "description": "hear-no-evil monkey"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "hear_no_evil"
+    ]
+  , "tags": [
+      "monkey"
+    , "deaf"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🙊"
+  , "description": "speak-no-evil monkey"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "speak_no_evil"
+    ]
+  , "tags": [
+      "monkey"
+    , "mute"
+    , "hush"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💋"
+  , "description": "kiss mark"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "kiss"
+    ]
+  , "tags": [
+      "lipstick"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💌"
+  , "description": "love letter"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "love_letter"
+    ]
+  , "tags": [
+      "email"
+    , "envelope"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💘"
+  , "description": "heart with arrow"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "cupid"
+    ]
+  , "tags": [
+      "love"
+    , "heart"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💝"
+  , "description": "heart with ribbon"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "gift_heart"
+    ]
+  , "tags": [
+      "chocolates"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💖"
+  , "description": "sparkling heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "sparkling_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💗"
+  , "description": "growing heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "heartpulse"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💓"
+  , "description": "beating heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "heartbeat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💞"
+  , "description": "revolving hearts"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "revolving_hearts"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💕"
+  , "description": "two hearts"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "two_hearts"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💟"
+  , "description": "heart decoration"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "heart_decoration"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "❣️"
+  , "description": "heart exclamation"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "heavy_heart_exclamation"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "💔"
+  , "description": "broken heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "broken_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "❤️"
+  , "description": "red heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "heart"
+    ]
+  , "tags": [
+      "love"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧡"
+  , "description": "orange heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "orange_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "💛"
+  , "description": "yellow heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "yellow_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💚"
+  , "description": "green heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "green_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💙"
+  , "description": "blue heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "blue_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💜"
+  , "description": "purple heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "purple_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤎"
+  , "description": "brown heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "brown_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🖤"
+  , "description": "black heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "black_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🤍"
+  , "description": "white heart"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "white_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "💯"
+  , "description": "hundred points"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "100"
+    ]
+  , "tags": [
+      "score"
+    , "perfect"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💢"
+  , "description": "anger symbol"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "anger"
+    ]
+  , "tags": [
+      "angry"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💥"
+  , "description": "collision"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "boom"
+    , "collision"
+    ]
+  , "tags": [
+      "explode"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💫"
+  , "description": "dizzy"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "dizzy"
+    ]
+  , "tags": [
+      "star"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💦"
+  , "description": "sweat droplets"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "sweat_drops"
+    ]
+  , "tags": [
+      "water"
+    , "workout"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💨"
+  , "description": "dashing away"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "dash"
+    ]
+  , "tags": [
+      "wind"
+    , "blow"
+    , "fast"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕳️"
+  , "description": "hole"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "hole"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "💣"
+  , "description": "bomb"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "bomb"
+    ]
+  , "tags": [
+      "boom"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💬"
+  , "description": "speech balloon"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "speech_balloon"
+    ]
+  , "tags": [
+      "comment"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👁️‍🗨️"
+  , "description": "eye in speech bubble"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "eye_speech_bubble"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🗨️"
+  , "description": "left speech bubble"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "left_speech_bubble"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🗯️"
+  , "description": "right anger bubble"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "right_anger_bubble"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "💭"
+  , "description": "thought balloon"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "thought_balloon"
+    ]
+  , "tags": [
+      "thinking"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💤"
+  , "description": "zzz"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "zzz"
+    ]
+  , "tags": [
+      "sleeping"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👋"
+  , "description": "waving hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "wave"
+    ]
+  , "tags": [
+      "goodbye"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤚"
+  , "description": "raised back of hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "raised_back_of_hand"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🖐️"
+  , "description": "hand with fingers splayed"
+  , "category": "People & Body"
+  , "aliases": [
+      "raised_hand_with_fingers_splayed"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "✋"
+  , "description": "raised hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "hand"
+    , "raised_hand"
+    ]
+  , "tags": [
+      "highfive"
+    , "stop"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🖖"
+  , "description": "vulcan salute"
+  , "category": "People & Body"
+  , "aliases": [
+      "vulcan_salute"
+    ]
+  , "tags": [
+      "prosper"
+    , "spock"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "8.3"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👌"
+  , "description": "OK hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "ok_hand"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤌"
+  , "description": "pinched fingers"
+  , "category": "People & Body"
+  , "aliases": [
+      "pinched_fingers"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤏"
+  , "description": "pinching hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "pinching_hand"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "✌️"
+  , "description": "victory hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "v"
+    ]
+  , "tags": [
+      "victory"
+    , "peace"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤞"
+  , "description": "crossed fingers"
+  , "category": "People & Body"
+  , "aliases": [
+      "crossed_fingers"
+    ]
+  , "tags": [
+      "luck"
+    , "hopeful"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤟"
+  , "description": "love-you gesture"
+  , "category": "People & Body"
+  , "aliases": [
+      "love_you_gesture"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤘"
+  , "description": "sign of the horns"
+  , "category": "People & Body"
+  , "aliases": [
+      "metal"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤙"
+  , "description": "call me hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "call_me_hand"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👈"
+  , "description": "backhand index pointing left"
+  , "category": "People & Body"
+  , "aliases": [
+      "point_left"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👉"
+  , "description": "backhand index pointing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "point_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👆"
+  , "description": "backhand index pointing up"
+  , "category": "People & Body"
+  , "aliases": [
+      "point_up_2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🖕"
+  , "description": "middle finger"
+  , "category": "People & Body"
+  , "aliases": [
+      "middle_finger"
+    , "fu"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👇"
+  , "description": "backhand index pointing down"
+  , "category": "People & Body"
+  , "aliases": [
+      "point_down"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "☝️"
+  , "description": "index pointing up"
+  , "category": "People & Body"
+  , "aliases": [
+      "point_up"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👍"
+  , "description": "thumbs up"
+  , "category": "People & Body"
+  , "aliases": [
+      "+1"
+    , "thumbsup"
+    ]
+  , "tags": [
+      "approve"
+    , "ok"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👎"
+  , "description": "thumbs down"
+  , "category": "People & Body"
+  , "aliases": [
+      "-1"
+    , "thumbsdown"
+    ]
+  , "tags": [
+      "disapprove"
+    , "bury"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "✊"
+  , "description": "raised fist"
+  , "category": "People & Body"
+  , "aliases": [
+      "fist_raised"
+    , "fist"
+    ]
+  , "tags": [
+      "power"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👊"
+  , "description": "oncoming fist"
+  , "category": "People & Body"
+  , "aliases": [
+      "fist_oncoming"
+    , "facepunch"
+    , "punch"
+    ]
+  , "tags": [
+      "attack"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤛"
+  , "description": "left-facing fist"
+  , "category": "People & Body"
+  , "aliases": [
+      "fist_left"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤜"
+  , "description": "right-facing fist"
+  , "category": "People & Body"
+  , "aliases": [
+      "fist_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👏"
+  , "description": "clapping hands"
+  , "category": "People & Body"
+  , "aliases": [
+      "clap"
+    ]
+  , "tags": [
+      "praise"
+    , "applause"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙌"
+  , "description": "raising hands"
+  , "category": "People & Body"
+  , "aliases": [
+      "raised_hands"
+    ]
+  , "tags": [
+      "hooray"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👐"
+  , "description": "open hands"
+  , "category": "People & Body"
+  , "aliases": [
+      "open_hands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤲"
+  , "description": "palms up together"
+  , "category": "People & Body"
+  , "aliases": [
+      "palms_up_together"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤝"
+  , "description": "handshake"
+  , "category": "People & Body"
+  , "aliases": [
+      "handshake"
+    ]
+  , "tags": [
+      "deal"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🙏"
+  , "description": "folded hands"
+  , "category": "People & Body"
+  , "aliases": [
+      "pray"
+    ]
+  , "tags": [
+      "please"
+    , "hope"
+    , "wish"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "✍️"
+  , "description": "writing hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "writing_hand"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💅"
+  , "description": "nail polish"
+  , "category": "People & Body"
+  , "aliases": [
+      "nail_care"
+    ]
+  , "tags": [
+      "beauty"
+    , "manicure"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤳"
+  , "description": "selfie"
+  , "category": "People & Body"
+  , "aliases": [
+      "selfie"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💪"
+  , "description": "flexed biceps"
+  , "category": "People & Body"
+  , "aliases": [
+      "muscle"
+    ]
+  , "tags": [
+      "flex"
+    , "bicep"
+    , "strong"
+    , "workout"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🦾"
+  , "description": "mechanical arm"
+  , "category": "People & Body"
+  , "aliases": [
+      "mechanical_arm"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🦿"
+  , "description": "mechanical leg"
+  , "category": "People & Body"
+  , "aliases": [
+      "mechanical_leg"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🦵"
+  , "description": "leg"
+  , "category": "People & Body"
+  , "aliases": [
+      "leg"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🦶"
+  , "description": "foot"
+  , "category": "People & Body"
+  , "aliases": [
+      "foot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👂"
+  , "description": "ear"
+  , "category": "People & Body"
+  , "aliases": [
+      "ear"
+    ]
+  , "tags": [
+      "hear"
+    , "sound"
+    , "listen"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🦻"
+  , "description": "ear with hearing aid"
+  , "category": "People & Body"
+  , "aliases": [
+      "ear_with_hearing_aid"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👃"
+  , "description": "nose"
+  , "category": "People & Body"
+  , "aliases": [
+      "nose"
+    ]
+  , "tags": [
+      "smell"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧠"
+  , "description": "brain"
+  , "category": "People & Body"
+  , "aliases": [
+      "brain"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🫀"
+  , "description": "anatomical heart"
+  , "category": "People & Body"
+  , "aliases": [
+      "anatomical_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🫁"
+  , "description": "lungs"
+  , "category": "People & Body"
+  , "aliases": [
+      "lungs"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🦷"
+  , "description": "tooth"
+  , "category": "People & Body"
+  , "aliases": [
+      "tooth"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦴"
+  , "description": "bone"
+  , "category": "People & Body"
+  , "aliases": [
+      "bone"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "👀"
+  , "description": "eyes"
+  , "category": "People & Body"
+  , "aliases": [
+      "eyes"
+    ]
+  , "tags": [
+      "look"
+    , "see"
+    , "watch"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👁️"
+  , "description": "eye"
+  , "category": "People & Body"
+  , "aliases": [
+      "eye"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "👅"
+  , "description": "tongue"
+  , "category": "People & Body"
+  , "aliases": [
+      "tongue"
+    ]
+  , "tags": [
+      "taste"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👄"
+  , "description": "mouth"
+  , "category": "People & Body"
+  , "aliases": [
+      "lips"
+    ]
+  , "tags": [
+      "kiss"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👶"
+  , "description": "baby"
+  , "category": "People & Body"
+  , "aliases": [
+      "baby"
+    ]
+  , "tags": [
+      "child"
+    , "newborn"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧒"
+  , "description": "child"
+  , "category": "People & Body"
+  , "aliases": [
+      "child"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👦"
+  , "description": "boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "boy"
+    ]
+  , "tags": [
+      "child"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👧"
+  , "description": "girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "girl"
+    ]
+  , "tags": [
+      "child"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑"
+  , "description": "person"
+  , "category": "People & Body"
+  , "aliases": [
+      "adult"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👱"
+  , "description": "person: blond hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "blond_haired_person"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨"
+  , "description": "man"
+  , "category": "People & Body"
+  , "aliases": [
+      "man"
+    ]
+  , "tags": [
+      "mustache"
+    , "father"
+    , "dad"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧔"
+  , "description": "man: beard"
+  , "category": "People & Body"
+  , "aliases": [
+      "bearded_person"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🦰"
+  , "description": "man: red hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "red_haired_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🦱"
+  , "description": "man: curly hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "curly_haired_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🦳"
+  , "description": "man: white hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "white_haired_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🦲"
+  , "description": "man: bald"
+  , "category": "People & Body"
+  , "aliases": [
+      "bald_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩"
+  , "description": "woman"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman"
+    ]
+  , "tags": [
+      "girls"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🦰"
+  , "description": "woman: red hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "red_haired_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🦰"
+  , "description": "person: red hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_red_hair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🦱"
+  , "description": "woman: curly hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "curly_haired_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🦱"
+  , "description": "person: curly hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_curly_hair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🦳"
+  , "description": "woman: white hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "white_haired_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🦳"
+  , "description": "person: white hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_white_hair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🦲"
+  , "description": "woman: bald"
+  , "category": "People & Body"
+  , "aliases": [
+      "bald_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🦲"
+  , "description": "person: bald"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_bald"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👱‍♀️"
+  , "description": "woman: blond hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "blond_haired_woman"
+    , "blonde_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👱‍♂️"
+  , "description": "man: blond hair"
+  , "category": "People & Body"
+  , "aliases": [
+      "blond_haired_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧓"
+  , "description": "older person"
+  , "category": "People & Body"
+  , "aliases": [
+      "older_adult"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👴"
+  , "description": "old man"
+  , "category": "People & Body"
+  , "aliases": [
+      "older_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👵"
+  , "description": "old woman"
+  , "category": "People & Body"
+  , "aliases": [
+      "older_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙍"
+  , "description": "person frowning"
+  , "category": "People & Body"
+  , "aliases": [
+      "frowning_person"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙍‍♂️"
+  , "description": "man frowning"
+  , "category": "People & Body"
+  , "aliases": [
+      "frowning_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙍‍♀️"
+  , "description": "woman frowning"
+  , "category": "People & Body"
+  , "aliases": [
+      "frowning_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙎"
+  , "description": "person pouting"
+  , "category": "People & Body"
+  , "aliases": [
+      "pouting_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙎‍♂️"
+  , "description": "man pouting"
+  , "category": "People & Body"
+  , "aliases": [
+      "pouting_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙎‍♀️"
+  , "description": "woman pouting"
+  , "category": "People & Body"
+  , "aliases": [
+      "pouting_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙅"
+  , "description": "person gesturing NO"
+  , "category": "People & Body"
+  , "aliases": [
+      "no_good"
+    ]
+  , "tags": [
+      "stop"
+    , "halt"
+    , "denied"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙅‍♂️"
+  , "description": "man gesturing NO"
+  , "category": "People & Body"
+  , "aliases": [
+      "no_good_man"
+    , "ng_man"
+    ]
+  , "tags": [
+      "stop"
+    , "halt"
+    , "denied"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙅‍♀️"
+  , "description": "woman gesturing NO"
+  , "category": "People & Body"
+  , "aliases": [
+      "no_good_woman"
+    , "ng_woman"
+    ]
+  , "tags": [
+      "stop"
+    , "halt"
+    , "denied"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙆"
+  , "description": "person gesturing OK"
+  , "category": "People & Body"
+  , "aliases": [
+      "ok_person"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙆‍♂️"
+  , "description": "man gesturing OK"
+  , "category": "People & Body"
+  , "aliases": [
+      "ok_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙆‍♀️"
+  , "description": "woman gesturing OK"
+  , "category": "People & Body"
+  , "aliases": [
+      "ok_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💁"
+  , "description": "person tipping hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "tipping_hand_person"
+    , "information_desk_person"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💁‍♂️"
+  , "description": "man tipping hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "tipping_hand_man"
+    , "sassy_man"
+    ]
+  , "tags": [
+      "information"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💁‍♀️"
+  , "description": "woman tipping hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "tipping_hand_woman"
+    , "sassy_woman"
+    ]
+  , "tags": [
+      "information"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙋"
+  , "description": "person raising hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "raising_hand"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙋‍♂️"
+  , "description": "man raising hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "raising_hand_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙋‍♀️"
+  , "description": "woman raising hand"
+  , "category": "People & Body"
+  , "aliases": [
+      "raising_hand_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧏"
+  , "description": "deaf person"
+  , "category": "People & Body"
+  , "aliases": [
+      "deaf_person"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧏‍♂️"
+  , "description": "deaf man"
+  , "category": "People & Body"
+  , "aliases": [
+      "deaf_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧏‍♀️"
+  , "description": "deaf woman"
+  , "category": "People & Body"
+  , "aliases": [
+      "deaf_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙇"
+  , "description": "person bowing"
+  , "category": "People & Body"
+  , "aliases": [
+      "bow"
+    ]
+  , "tags": [
+      "respect"
+    , "thanks"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙇‍♂️"
+  , "description": "man bowing"
+  , "category": "People & Body"
+  , "aliases": [
+      "bowing_man"
+    ]
+  , "tags": [
+      "respect"
+    , "thanks"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🙇‍♀️"
+  , "description": "woman bowing"
+  , "category": "People & Body"
+  , "aliases": [
+      "bowing_woman"
+    ]
+  , "tags": [
+      "respect"
+    , "thanks"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤦"
+  , "description": "person facepalming"
+  , "category": "People & Body"
+  , "aliases": [
+      "facepalm"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤦‍♂️"
+  , "description": "man facepalming"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_facepalming"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤦‍♀️"
+  , "description": "woman facepalming"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_facepalming"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤷"
+  , "description": "person shrugging"
+  , "category": "People & Body"
+  , "aliases": [
+      "shrug"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤷‍♂️"
+  , "description": "man shrugging"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_shrugging"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤷‍♀️"
+  , "description": "woman shrugging"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_shrugging"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍⚕️"
+  , "description": "health worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "health_worker"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍⚕️"
+  , "description": "man health worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_health_worker"
+    ]
+  , "tags": [
+      "doctor"
+    , "nurse"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍⚕️"
+  , "description": "woman health worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_health_worker"
+    ]
+  , "tags": [
+      "doctor"
+    , "nurse"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🎓"
+  , "description": "student"
+  , "category": "People & Body"
+  , "aliases": [
+      "student"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🎓"
+  , "description": "man student"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_student"
+    ]
+  , "tags": [
+      "graduation"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🎓"
+  , "description": "woman student"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_student"
+    ]
+  , "tags": [
+      "graduation"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🏫"
+  , "description": "teacher"
+  , "category": "People & Body"
+  , "aliases": [
+      "teacher"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🏫"
+  , "description": "man teacher"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_teacher"
+    ]
+  , "tags": [
+      "school"
+    , "professor"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🏫"
+  , "description": "woman teacher"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_teacher"
+    ]
+  , "tags": [
+      "school"
+    , "professor"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍⚖️"
+  , "description": "judge"
+  , "category": "People & Body"
+  , "aliases": [
+      "judge"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍⚖️"
+  , "description": "man judge"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_judge"
+    ]
+  , "tags": [
+      "justice"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍⚖️"
+  , "description": "woman judge"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_judge"
+    ]
+  , "tags": [
+      "justice"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🌾"
+  , "description": "farmer"
+  , "category": "People & Body"
+  , "aliases": [
+      "farmer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🌾"
+  , "description": "man farmer"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_farmer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🌾"
+  , "description": "woman farmer"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_farmer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🍳"
+  , "description": "cook"
+  , "category": "People & Body"
+  , "aliases": [
+      "cook"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🍳"
+  , "description": "man cook"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_cook"
+    ]
+  , "tags": [
+      "chef"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🍳"
+  , "description": "woman cook"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_cook"
+    ]
+  , "tags": [
+      "chef"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🔧"
+  , "description": "mechanic"
+  , "category": "People & Body"
+  , "aliases": [
+      "mechanic"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🔧"
+  , "description": "man mechanic"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_mechanic"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🔧"
+  , "description": "woman mechanic"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_mechanic"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🏭"
+  , "description": "factory worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "factory_worker"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🏭"
+  , "description": "man factory worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_factory_worker"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🏭"
+  , "description": "woman factory worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_factory_worker"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍💼"
+  , "description": "office worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "office_worker"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍💼"
+  , "description": "man office worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_office_worker"
+    ]
+  , "tags": [
+      "business"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍💼"
+  , "description": "woman office worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_office_worker"
+    ]
+  , "tags": [
+      "business"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🔬"
+  , "description": "scientist"
+  , "category": "People & Body"
+  , "aliases": [
+      "scientist"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🔬"
+  , "description": "man scientist"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_scientist"
+    ]
+  , "tags": [
+      "research"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🔬"
+  , "description": "woman scientist"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_scientist"
+    ]
+  , "tags": [
+      "research"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍💻"
+  , "description": "technologist"
+  , "category": "People & Body"
+  , "aliases": [
+      "technologist"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍💻"
+  , "description": "man technologist"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_technologist"
+    ]
+  , "tags": [
+      "coder"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍💻"
+  , "description": "woman technologist"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_technologist"
+    ]
+  , "tags": [
+      "coder"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🎤"
+  , "description": "singer"
+  , "category": "People & Body"
+  , "aliases": [
+      "singer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🎤"
+  , "description": "man singer"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_singer"
+    ]
+  , "tags": [
+      "rockstar"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🎤"
+  , "description": "woman singer"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_singer"
+    ]
+  , "tags": [
+      "rockstar"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🎨"
+  , "description": "artist"
+  , "category": "People & Body"
+  , "aliases": [
+      "artist"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🎨"
+  , "description": "man artist"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_artist"
+    ]
+  , "tags": [
+      "painter"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🎨"
+  , "description": "woman artist"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_artist"
+    ]
+  , "tags": [
+      "painter"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍✈️"
+  , "description": "pilot"
+  , "category": "People & Body"
+  , "aliases": [
+      "pilot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍✈️"
+  , "description": "man pilot"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_pilot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍✈️"
+  , "description": "woman pilot"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_pilot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🚀"
+  , "description": "astronaut"
+  , "category": "People & Body"
+  , "aliases": [
+      "astronaut"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🚀"
+  , "description": "man astronaut"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_astronaut"
+    ]
+  , "tags": [
+      "space"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🚀"
+  , "description": "woman astronaut"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_astronaut"
+    ]
+  , "tags": [
+      "space"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🚒"
+  , "description": "firefighter"
+  , "category": "People & Body"
+  , "aliases": [
+      "firefighter"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🚒"
+  , "description": "man firefighter"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_firefighter"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🚒"
+  , "description": "woman firefighter"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_firefighter"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👮"
+  , "description": "police officer"
+  , "category": "People & Body"
+  , "aliases": [
+      "police_officer"
+    , "cop"
+    ]
+  , "tags": [
+      "law"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👮‍♂️"
+  , "description": "man police officer"
+  , "category": "People & Body"
+  , "aliases": [
+      "policeman"
+    ]
+  , "tags": [
+      "law"
+    , "cop"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👮‍♀️"
+  , "description": "woman police officer"
+  , "category": "People & Body"
+  , "aliases": [
+      "policewoman"
+    ]
+  , "tags": [
+      "law"
+    , "cop"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🕵️"
+  , "description": "detective"
+  , "category": "People & Body"
+  , "aliases": [
+      "detective"
+    ]
+  , "tags": [
+      "sleuth"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🕵️‍♂️"
+  , "description": "man detective"
+  , "category": "People & Body"
+  , "aliases": [
+      "male_detective"
+    ]
+  , "tags": [
+      "sleuth"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🕵️‍♀️"
+  , "description": "woman detective"
+  , "category": "People & Body"
+  , "aliases": [
+      "female_detective"
+    ]
+  , "tags": [
+      "sleuth"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💂"
+  , "description": "guard"
+  , "category": "People & Body"
+  , "aliases": [
+      "guard"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💂‍♂️"
+  , "description": "man guard"
+  , "category": "People & Body"
+  , "aliases": [
+      "guardsman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💂‍♀️"
+  , "description": "woman guard"
+  , "category": "People & Body"
+  , "aliases": [
+      "guardswoman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🥷"
+  , "description": "ninja"
+  , "category": "People & Body"
+  , "aliases": [
+      "ninja"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👷"
+  , "description": "construction worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "construction_worker"
+    ]
+  , "tags": [
+      "helmet"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👷‍♂️"
+  , "description": "man construction worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "construction_worker_man"
+    ]
+  , "tags": [
+      "helmet"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👷‍♀️"
+  , "description": "woman construction worker"
+  , "category": "People & Body"
+  , "aliases": [
+      "construction_worker_woman"
+    ]
+  , "tags": [
+      "helmet"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤴"
+  , "description": "prince"
+  , "category": "People & Body"
+  , "aliases": [
+      "prince"
+    ]
+  , "tags": [
+      "crown"
+    , "royal"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👸"
+  , "description": "princess"
+  , "category": "People & Body"
+  , "aliases": [
+      "princess"
+    ]
+  , "tags": [
+      "crown"
+    , "royal"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👳"
+  , "description": "person wearing turban"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_with_turban"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👳‍♂️"
+  , "description": "man wearing turban"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_with_turban"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👳‍♀️"
+  , "description": "woman wearing turban"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_with_turban"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👲"
+  , "description": "person with skullcap"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_with_gua_pi_mao"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧕"
+  , "description": "woman with headscarf"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_with_headscarf"
+    ]
+  , "tags": [
+      "hijab"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤵"
+  , "description": "person in tuxedo"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_in_tuxedo"
+    ]
+  , "tags": [
+      "groom"
+    , "marriage"
+    , "wedding"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤵‍♂️"
+  , "description": "man in tuxedo"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_in_tuxedo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤵‍♀️"
+  , "description": "woman in tuxedo"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_in_tuxedo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👰"
+  , "description": "person with veil"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_with_veil"
+    ]
+  , "tags": [
+      "marriage"
+    , "wedding"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👰‍♂️"
+  , "description": "man with veil"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_with_veil"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👰‍♀️"
+  , "description": "woman with veil"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_with_veil",
+      "bride_with_veil"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤰"
+  , "description": "pregnant woman"
+  , "category": "People & Body"
+  , "aliases": [
+      "pregnant_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤱"
+  , "description": "breast-feeding"
+  , "category": "People & Body"
+  , "aliases": [
+      "breast_feeding"
+    ]
+  , "tags": [
+      "nursing"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🍼"
+  , "description": "woman feeding baby"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_feeding_baby"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🍼"
+  , "description": "man feeding baby"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_feeding_baby"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🍼"
+  , "description": "person feeding baby"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_feeding_baby"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👼"
+  , "description": "baby angel"
+  , "category": "People & Body"
+  , "aliases": [
+      "angel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🎅"
+  , "description": "Santa Claus"
+  , "category": "People & Body"
+  , "aliases": [
+      "santa"
+    ]
+  , "tags": [
+      "christmas"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤶"
+  , "description": "Mrs. Claus"
+  , "category": "People & Body"
+  , "aliases": [
+      "mrs_claus"
+    ]
+  , "tags": [
+      "santa"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🎄"
+  , "description": "mx claus"
+  , "category": "People & Body"
+  , "aliases": [
+      "mx_claus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🦸"
+  , "description": "superhero"
+  , "category": "People & Body"
+  , "aliases": [
+      "superhero"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🦸‍♂️"
+  , "description": "man superhero"
+  , "category": "People & Body"
+  , "aliases": [
+      "superhero_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🦸‍♀️"
+  , "description": "woman superhero"
+  , "category": "People & Body"
+  , "aliases": [
+      "superhero_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🦹"
+  , "description": "supervillain"
+  , "category": "People & Body"
+  , "aliases": [
+      "supervillain"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🦹‍♂️"
+  , "description": "man supervillain"
+  , "category": "People & Body"
+  , "aliases": [
+      "supervillain_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🦹‍♀️"
+  , "description": "woman supervillain"
+  , "category": "People & Body"
+  , "aliases": [
+      "supervillain_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧙"
+  , "description": "mage"
+  , "category": "People & Body"
+  , "aliases": [
+      "mage"
+    ]
+  , "tags": [
+      "wizard"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧙‍♂️"
+  , "description": "man mage"
+  , "category": "People & Body"
+  , "aliases": [
+      "mage_man"
+    ]
+  , "tags": [
+      "wizard"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧙‍♀️"
+  , "description": "woman mage"
+  , "category": "People & Body"
+  , "aliases": [
+      "mage_woman"
+    ]
+  , "tags": [
+      "wizard"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧚"
+  , "description": "fairy"
+  , "category": "People & Body"
+  , "aliases": [
+      "fairy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧚‍♂️"
+  , "description": "man fairy"
+  , "category": "People & Body"
+  , "aliases": [
+      "fairy_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧚‍♀️"
+  , "description": "woman fairy"
+  , "category": "People & Body"
+  , "aliases": [
+      "fairy_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧛"
+  , "description": "vampire"
+  , "category": "People & Body"
+  , "aliases": [
+      "vampire"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧛‍♂️"
+  , "description": "man vampire"
+  , "category": "People & Body"
+  , "aliases": [
+      "vampire_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧛‍♀️"
+  , "description": "woman vampire"
+  , "category": "People & Body"
+  , "aliases": [
+      "vampire_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧜"
+  , "description": "merperson"
+  , "category": "People & Body"
+  , "aliases": [
+      "merperson"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧜‍♂️"
+  , "description": "merman"
+  , "category": "People & Body"
+  , "aliases": [
+      "merman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧜‍♀️"
+  , "description": "mermaid"
+  , "category": "People & Body"
+  , "aliases": [
+      "mermaid"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧝"
+  , "description": "elf"
+  , "category": "People & Body"
+  , "aliases": [
+      "elf"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧝‍♂️"
+  , "description": "man elf"
+  , "category": "People & Body"
+  , "aliases": [
+      "elf_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧝‍♀️"
+  , "description": "woman elf"
+  , "category": "People & Body"
+  , "aliases": [
+      "elf_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧞"
+  , "description": "genie"
+  , "category": "People & Body"
+  , "aliases": [
+      "genie"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧞‍♂️"
+  , "description": "man genie"
+  , "category": "People & Body"
+  , "aliases": [
+      "genie_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧞‍♀️"
+  , "description": "woman genie"
+  , "category": "People & Body"
+  , "aliases": [
+      "genie_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧟"
+  , "description": "zombie"
+  , "category": "People & Body"
+  , "aliases": [
+      "zombie"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧟‍♂️"
+  , "description": "man zombie"
+  , "category": "People & Body"
+  , "aliases": [
+      "zombie_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧟‍♀️"
+  , "description": "woman zombie"
+  , "category": "People & Body"
+  , "aliases": [
+      "zombie_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "💆"
+  , "description": "person getting massage"
+  , "category": "People & Body"
+  , "aliases": [
+      "massage"
+    ]
+  , "tags": [
+      "spa"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💆‍♂️"
+  , "description": "man getting massage"
+  , "category": "People & Body"
+  , "aliases": [
+      "massage_man"
+    ]
+  , "tags": [
+      "spa"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💆‍♀️"
+  , "description": "woman getting massage"
+  , "category": "People & Body"
+  , "aliases": [
+      "massage_woman"
+    ]
+  , "tags": [
+      "spa"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💇"
+  , "description": "person getting haircut"
+  , "category": "People & Body"
+  , "aliases": [
+      "haircut"
+    ]
+  , "tags": [
+      "beauty"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💇‍♂️"
+  , "description": "man getting haircut"
+  , "category": "People & Body"
+  , "aliases": [
+      "haircut_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💇‍♀️"
+  , "description": "woman getting haircut"
+  , "category": "People & Body"
+  , "aliases": [
+      "haircut_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚶"
+  , "description": "person walking"
+  , "category": "People & Body"
+  , "aliases": [
+      "walking"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚶‍♂️"
+  , "description": "man walking"
+  , "category": "People & Body"
+  , "aliases": [
+      "walking_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚶‍♀️"
+  , "description": "woman walking"
+  , "category": "People & Body"
+  , "aliases": [
+      "walking_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧍"
+  , "description": "person standing"
+  , "category": "People & Body"
+  , "aliases": [
+      "standing_person"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧍‍♂️"
+  , "description": "man standing"
+  , "category": "People & Body"
+  , "aliases": [
+      "standing_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧍‍♀️"
+  , "description": "woman standing"
+  , "category": "People & Body"
+  , "aliases": [
+      "standing_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧎"
+  , "description": "person kneeling"
+  , "category": "People & Body"
+  , "aliases": [
+      "kneeling_person"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧎‍♂️"
+  , "description": "man kneeling"
+  , "category": "People & Body"
+  , "aliases": [
+      "kneeling_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧎‍♀️"
+  , "description": "woman kneeling"
+  , "category": "People & Body"
+  , "aliases": [
+      "kneeling_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🦯"
+  , "description": "person with white cane"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_with_probing_cane"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🦯"
+  , "description": "man with white cane"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_with_probing_cane"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🦯"
+  , "description": "woman with white cane"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_with_probing_cane"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🦼"
+  , "description": "person in motorized wheelchair"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_in_motorized_wheelchair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🦼"
+  , "description": "man in motorized wheelchair"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_in_motorized_wheelchair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🦼"
+  , "description": "woman in motorized wheelchair"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_in_motorized_wheelchair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🦽"
+  , "description": "person in manual wheelchair"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_in_manual_wheelchair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.1"
+  , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🦽"
+  , "description": "man in manual wheelchair"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_in_manual_wheelchair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🦽"
+  , "description": "woman in manual wheelchair"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_in_manual_wheelchair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏃"
+  , "description": "person running"
+  , "category": "People & Body"
+  , "aliases": [
+      "runner"
+    , "running"
+    ]
+  , "tags": [
+      "exercise"
+    , "workout"
+    , "marathon"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏃‍♂️"
+  , "description": "man running"
+  , "category": "People & Body"
+  , "aliases": [
+      "running_man"
+    ]
+  , "tags": [
+      "exercise"
+    , "workout"
+    , "marathon"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏃‍♀️"
+  , "description": "woman running"
+  , "category": "People & Body"
+  , "aliases": [
+      "running_woman"
+    ]
+  , "tags": [
+      "exercise"
+    , "workout"
+    , "marathon"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💃"
+  , "description": "woman dancing"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_dancing"
+    , "dancer"
+    ]
+  , "tags": [
+      "dress"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🕺"
+  , "description": "man dancing"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_dancing"
+    ]
+  , "tags": [
+      "dancer"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🕴️"
+  , "description": "person in suit levitating"
+  , "category": "People & Body"
+  , "aliases": [
+      "business_suit_levitating"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👯"
+  , "description": "people with bunny ears"
+  , "category": "People & Body"
+  , "aliases": [
+      "dancers"
+    ]
+  , "tags": [
+      "bunny"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👯‍♂️"
+  , "description": "men with bunny ears"
+  , "category": "People & Body"
+  , "aliases": [
+      "dancing_men"
+    ]
+  , "tags": [
+      "bunny"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "👯‍♀️"
+  , "description": "women with bunny ears"
+  , "category": "People & Body"
+  , "aliases": [
+      "dancing_women"
+    ]
+  , "tags": [
+      "bunny"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧖"
+  , "description": "person in steamy room"
+  , "category": "People & Body"
+  , "aliases": [
+      "sauna_person"
+    ]
+  , "tags": [
+      "steamy"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧖‍♂️"
+  , "description": "man in steamy room"
+  , "category": "People & Body"
+  , "aliases": [
+      "sauna_man"
+    ]
+  , "tags": [
+      "steamy"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧖‍♀️"
+  , "description": "woman in steamy room"
+  , "category": "People & Body"
+  , "aliases": [
+      "sauna_woman"
+    ]
+  , "tags": [
+      "steamy"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧗"
+  , "description": "person climbing"
+  , "category": "People & Body"
+  , "aliases": [
+      "climbing"
+    ]
+  , "tags": [
+      "bouldering"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧗‍♂️"
+  , "description": "man climbing"
+  , "category": "People & Body"
+  , "aliases": [
+      "climbing_man"
+    ]
+  , "tags": [
+      "bouldering"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧗‍♀️"
+  , "description": "woman climbing"
+  , "category": "People & Body"
+  , "aliases": [
+      "climbing_woman"
+    ]
+  , "tags": [
+      "bouldering"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤺"
+  , "description": "person fencing"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_fencing"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🏇"
+  , "description": "horse racing"
+  , "category": "People & Body"
+  , "aliases": [
+      "horse_racing"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "⛷️"
+  , "description": "skier"
+  , "category": "People & Body"
+  , "aliases": [
+      "skier"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏂"
+  , "description": "snowboarder"
+  , "category": "People & Body"
+  , "aliases": [
+      "snowboarder"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏌️"
+  , "description": "person golfing"
+  , "category": "People & Body"
+  , "aliases": [
+      "golfing"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏌️‍♂️"
+  , "description": "man golfing"
+  , "category": "People & Body"
+  , "aliases": [
+      "golfing_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏌️‍♀️"
+  , "description": "woman golfing"
+  , "category": "People & Body"
+  , "aliases": [
+      "golfing_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏄"
+  , "description": "person surfing"
+  , "category": "People & Body"
+  , "aliases": [
+      "surfer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏄‍♂️"
+  , "description": "man surfing"
+  , "category": "People & Body"
+  , "aliases": [
+      "surfing_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏄‍♀️"
+  , "description": "woman surfing"
+  , "category": "People & Body"
+  , "aliases": [
+      "surfing_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚣"
+  , "description": "person rowing boat"
+  , "category": "People & Body"
+  , "aliases": [
+      "rowboat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚣‍♂️"
+  , "description": "man rowing boat"
+  , "category": "People & Body"
+  , "aliases": [
+      "rowing_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚣‍♀️"
+  , "description": "woman rowing boat"
+  , "category": "People & Body"
+  , "aliases": [
+      "rowing_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏊"
+  , "description": "person swimming"
+  , "category": "People & Body"
+  , "aliases": [
+      "swimmer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏊‍♂️"
+  , "description": "man swimming"
+  , "category": "People & Body"
+  , "aliases": [
+      "swimming_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏊‍♀️"
+  , "description": "woman swimming"
+  , "category": "People & Body"
+  , "aliases": [
+      "swimming_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "⛹️"
+  , "description": "person bouncing ball"
+  , "category": "People & Body"
+  , "aliases": [
+      "bouncing_ball_person"
+    ]
+  , "tags": [
+      "basketball"
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "⛹️‍♂️"
+  , "description": "man bouncing ball"
+  , "category": "People & Body"
+  , "aliases": [
+      "bouncing_ball_man"
+    , "basketball_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "⛹️‍♀️"
+  , "description": "woman bouncing ball"
+  , "category": "People & Body"
+  , "aliases": [
+      "bouncing_ball_woman"
+    , "basketball_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏋️"
+  , "description": "person lifting weights"
+  , "category": "People & Body"
+  , "aliases": [
+      "weight_lifting"
+    ]
+  , "tags": [
+      "gym"
+    , "workout"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏋️‍♂️"
+  , "description": "man lifting weights"
+  , "category": "People & Body"
+  , "aliases": [
+      "weight_lifting_man"
+    ]
+  , "tags": [
+      "gym"
+    , "workout"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏋️‍♀️"
+  , "description": "woman lifting weights"
+  , "category": "People & Body"
+  , "aliases": [
+      "weight_lifting_woman"
+    ]
+  , "tags": [
+      "gym"
+    , "workout"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚴"
+  , "description": "person biking"
+  , "category": "People & Body"
+  , "aliases": [
+      "bicyclist"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚴‍♂️"
+  , "description": "man biking"
+  , "category": "People & Body"
+  , "aliases": [
+      "biking_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚴‍♀️"
+  , "description": "woman biking"
+  , "category": "People & Body"
+  , "aliases": [
+      "biking_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚵"
+  , "description": "person mountain biking"
+  , "category": "People & Body"
+  , "aliases": [
+      "mountain_bicyclist"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚵‍♂️"
+  , "description": "man mountain biking"
+  , "category": "People & Body"
+  , "aliases": [
+      "mountain_biking_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚵‍♀️"
+  , "description": "woman mountain biking"
+  , "category": "People & Body"
+  , "aliases": [
+      "mountain_biking_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤸"
+  , "description": "person cartwheeling"
+  , "category": "People & Body"
+  , "aliases": [
+      "cartwheeling"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤸‍♂️"
+  , "description": "man cartwheeling"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_cartwheeling"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤸‍♀️"
+  , "description": "woman cartwheeling"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_cartwheeling"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤼"
+  , "description": "people wrestling"
+  , "category": "People & Body"
+  , "aliases": [
+      "wrestling"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🤼‍♂️"
+  , "description": "men wrestling"
+  , "category": "People & Body"
+  , "aliases": [
+      "men_wrestling"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🤼‍♀️"
+  , "description": "women wrestling"
+  , "category": "People & Body"
+  , "aliases": [
+      "women_wrestling"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🤽"
+  , "description": "person playing water polo"
+  , "category": "People & Body"
+  , "aliases": [
+      "water_polo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤽‍♂️"
+  , "description": "man playing water polo"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_playing_water_polo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤽‍♀️"
+  , "description": "woman playing water polo"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_playing_water_polo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤾"
+  , "description": "person playing handball"
+  , "category": "People & Body"
+  , "aliases": [
+      "handball_person"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤾‍♂️"
+  , "description": "man playing handball"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_playing_handball"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤾‍♀️"
+  , "description": "woman playing handball"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_playing_handball"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤹"
+  , "description": "person juggling"
+  , "category": "People & Body"
+  , "aliases": [
+      "juggling_person"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤹‍♂️"
+  , "description": "man juggling"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_juggling"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🤹‍♀️"
+  , "description": "woman juggling"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_juggling"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧘"
+  , "description": "person in lotus position"
+  , "category": "People & Body"
+  , "aliases": [
+      "lotus_position"
+    ]
+  , "tags": [
+      "meditation"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧘‍♂️"
+  , "description": "man in lotus position"
+  , "category": "People & Body"
+  , "aliases": [
+      "lotus_position_man"
+    ]
+  , "tags": [
+      "meditation"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧘‍♀️"
+  , "description": "woman in lotus position"
+  , "category": "People & Body"
+  , "aliases": [
+      "lotus_position_woman"
+    ]
+  , "tags": [
+      "meditation"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🛀"
+  , "description": "person taking bath"
+  , "category": "People & Body"
+  , "aliases": [
+      "bath"
+    ]
+  , "tags": [
+      "shower"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🛌"
+  , "description": "person in bed"
+  , "category": "People & Body"
+  , "aliases": [
+      "sleeping_bed"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🤝‍🧑"
+  , "description": "people holding hands"
+  , "category": "People & Body"
+  , "aliases": [
+      "people_holding_hands"
+    ]
+  , "tags": [
+      "couple"
+    , "date"
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👭"
+  , "description": "women holding hands"
+  , "category": "People & Body"
+  , "aliases": [
+      "two_women_holding_hands"
+    ]
+  , "tags": [
+      "couple"
+    , "date"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👫"
+  , "description": "woman and man holding hands"
+  , "category": "People & Body"
+  , "aliases": [
+      "couple"
+    ]
+  , "tags": [
+      "date"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👬"
+  , "description": "men holding hands"
+  , "category": "People & Body"
+  , "aliases": [
+      "two_men_holding_hands"
+    ]
+  , "tags": [
+      "couple"
+    , "date"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "💏"
+  , "description": "kiss"
+  , "category": "People & Body"
+  , "aliases": [
+      "couplekiss"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👩‍❤️‍💋‍👨"
+  , "description": "kiss: woman, man"
+  , "category": "People & Body"
+  , "aliases": [
+      "couplekiss_man_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "👨‍❤️‍💋‍👨"
+  , "description": "kiss: man, man"
+  , "category": "People & Body"
+  , "aliases": [
+      "couplekiss_man_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👩‍❤️‍💋‍👩"
+  , "description": "kiss: woman, woman"
+  , "category": "People & Body"
+  , "aliases": [
+      "couplekiss_woman_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "💑"
+  , "description": "couple with heart"
+  , "category": "People & Body"
+  , "aliases": [
+      "couple_with_heart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👩‍❤️‍👨"
+  , "description": "couple with heart: woman, man"
+  , "category": "People & Body"
+  , "aliases": [
+      "couple_with_heart_woman_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "👨‍❤️‍👨"
+  , "description": "couple with heart: man, man"
+  , "category": "People & Body"
+  , "aliases": [
+      "couple_with_heart_man_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👩‍❤️‍👩"
+  , "description": "couple with heart: woman, woman"
+  , "category": "People & Body"
+  , "aliases": [
+      "couple_with_heart_woman_woman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👪"
+  , "description": "family"
+  , "category": "People & Body"
+  , "aliases": [
+      "family"
+    ]
+  , "tags": [
+      "home"
+    , "parents"
+    , "child"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👨‍👩‍👦"
+  , "description": "family: man, woman, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_woman_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "👨‍👩‍👧"
+  , "description": "family: man, woman, girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_woman_girl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👨‍👩‍👧‍👦"
+  , "description": "family: man, woman, girl, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_woman_girl_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👨‍👩‍👦‍👦"
+  , "description": "family: man, woman, boy, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_woman_boy_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👨‍👩‍👧‍👧"
+  , "description": "family: man, woman, girl, girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_woman_girl_girl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👨‍👨‍👦"
+  , "description": "family: man, man, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_man_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👨‍👨‍👧"
+  , "description": "family: man, man, girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_man_girl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👨‍👨‍👧‍👦"
+  , "description": "family: man, man, girl, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_man_girl_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👨‍👨‍👦‍👦"
+  , "description": "family: man, man, boy, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_man_boy_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👨‍👨‍👧‍👧"
+  , "description": "family: man, man, girl, girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_man_girl_girl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👩‍👩‍👦"
+  , "description": "family: woman, woman, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_woman_woman_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👩‍👩‍👧"
+  , "description": "family: woman, woman, girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_woman_woman_girl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👩‍👩‍👧‍👦"
+  , "description": "family: woman, woman, girl, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_woman_woman_girl_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👩‍👩‍👦‍👦"
+  , "description": "family: woman, woman, boy, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_woman_woman_boy_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👩‍👩‍👧‍👧"
+  , "description": "family: woman, woman, girl, girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_woman_woman_girl_girl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "👨‍👦"
+  , "description": "family: man, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "👨‍👦‍👦"
+  , "description": "family: man, boy, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_boy_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "👨‍👧"
+  , "description": "family: man, girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_girl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "👨‍👧‍👦"
+  , "description": "family: man, girl, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_girl_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "👨‍👧‍👧"
+  , "description": "family: man, girl, girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_man_girl_girl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "👩‍👦"
+  , "description": "family: woman, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_woman_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "👩‍👦‍👦"
+  , "description": "family: woman, boy, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_woman_boy_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "👩‍👧"
+  , "description": "family: woman, girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_woman_girl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "👩‍👧‍👦"
+  , "description": "family: woman, girl, boy"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_woman_girl_boy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "👩‍👧‍👧"
+  , "description": "family: woman, girl, girl"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_woman_girl_girl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "🗣️"
+  , "description": "speaking head"
+  , "category": "People & Body"
+  , "aliases": [
+      "speaking_head"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "👤"
+  , "description": "bust in silhouette"
+  , "category": "People & Body"
+  , "aliases": [
+      "bust_in_silhouette"
+    ]
+  , "tags": [
+      "user"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👥"
+  , "description": "busts in silhouette"
+  , "category": "People & Body"
+  , "aliases": [
+      "busts_in_silhouette"
+    ]
+  , "tags": [
+      "users"
+    , "group"
+    , "team"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🫂"
+  , "description": "people hugging"
+  , "category": "People & Body"
+  , "aliases": [
+      "people_hugging"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "👣"
+  , "description": "footprints"
+  , "category": "People & Body"
+  , "aliases": [
+      "footprints"
+    ]
+  , "tags": [
+      "feet"
+    , "tracks"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐵"
+  , "description": "monkey face"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "monkey_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐒"
+  , "description": "monkey"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "monkey"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦍"
+  , "description": "gorilla"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "gorilla"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦧"
+  , "description": "orangutan"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "orangutan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🐶"
+  , "description": "dog face"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "dog"
+    ]
+  , "tags": [
+      "pet"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐕"
+  , "description": "dog"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "dog2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦮"
+  , "description": "guide dog"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "guide_dog"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🐕‍🦺"
+  , "description": "service dog"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "service_dog"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🐩"
+  , "description": "poodle"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "poodle"
+    ]
+  , "tags": [
+      "dog"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐺"
+  , "description": "wolf"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "wolf"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦊"
+  , "description": "fox"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "fox_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦝"
+  , "description": "raccoon"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "raccoon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🐱"
+  , "description": "cat face"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "cat"
+    ]
+  , "tags": [
+      "pet"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐈"
+  , "description": "cat"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "cat2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐈‍⬛"
+  , "description": "black cat"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "black_cat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🦁"
+  , "description": "lion"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "lion"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🐯"
+  , "description": "tiger face"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "tiger"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐅"
+  , "description": "tiger"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "tiger2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐆"
+  , "description": "leopard"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "leopard"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐴"
+  , "description": "horse face"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "horse"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐎"
+  , "description": "horse"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "racehorse"
+    ]
+  , "tags": [
+      "speed"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦄"
+  , "description": "unicorn"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "unicorn"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🦓"
+  , "description": "zebra"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "zebra"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦌"
+  , "description": "deer"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "deer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦬"
+  , "description": "bison"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "bison"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🐮"
+  , "description": "cow face"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "cow"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐂"
+  , "description": "ox"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "ox"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐃"
+  , "description": "water buffalo"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "water_buffalo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐄"
+  , "description": "cow"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "cow2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐷"
+  , "description": "pig face"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "pig"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐖"
+  , "description": "pig"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "pig2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐗"
+  , "description": "boar"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "boar"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐽"
+  , "description": "pig nose"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "pig_nose"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐏"
+  , "description": "ram"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "ram"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐑"
+  , "description": "ewe"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "sheep"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐐"
+  , "description": "goat"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "goat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐪"
+  , "description": "camel"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "dromedary_camel"
+    ]
+  , "tags": [
+      "desert"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐫"
+  , "description": "two-hump camel"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "camel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦙"
+  , "description": "llama"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "llama"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦒"
+  , "description": "giraffe"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "giraffe"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🐘"
+  , "description": "elephant"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "elephant"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦣"
+  , "description": "mammoth"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "mammoth"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🦏"
+  , "description": "rhinoceros"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "rhinoceros"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦛"
+  , "description": "hippopotamus"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "hippopotamus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🐭"
+  , "description": "mouse face"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "mouse"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐁"
+  , "description": "mouse"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "mouse2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐀"
+  , "description": "rat"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "rat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐹"
+  , "description": "hamster"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "hamster"
+    ]
+  , "tags": [
+      "pet"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐰"
+  , "description": "rabbit face"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "rabbit"
+    ]
+  , "tags": [
+      "bunny"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐇"
+  , "description": "rabbit"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "rabbit2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐿️"
+  , "description": "chipmunk"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "chipmunk"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🦫"
+  , "description": "beaver"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "beaver"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🦔"
+  , "description": "hedgehog"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "hedgehog"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦇"
+  , "description": "bat"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "bat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🐻"
+  , "description": "bear"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "bear"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐻‍❄️"
+  , "description": "polar bear"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "polar_bear"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🐨"
+  , "description": "koala"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "koala"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐼"
+  , "description": "panda"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "panda_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦥"
+  , "description": "sloth"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "sloth"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🦦"
+  , "description": "otter"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "otter"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🦨"
+  , "description": "skunk"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "skunk"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🦘"
+  , "description": "kangaroo"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "kangaroo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦡"
+  , "description": "badger"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "badger"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🐾"
+  , "description": "paw prints"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "feet"
+    , "paw_prints"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦃"
+  , "description": "turkey"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "turkey"
+    ]
+  , "tags": [
+      "thanksgiving"
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🐔"
+  , "description": "chicken"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "chicken"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐓"
+  , "description": "rooster"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "rooster"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐣"
+  , "description": "hatching chick"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "hatching_chick"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐤"
+  , "description": "baby chick"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "baby_chick"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐥"
+  , "description": "front-facing baby chick"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "hatched_chick"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐦"
+  , "description": "bird"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "bird"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐧"
+  , "description": "penguin"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "penguin"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕊️"
+  , "description": "dove"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "dove"
+    ]
+  , "tags": [
+      "peace"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🦅"
+  , "description": "eagle"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "eagle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦆"
+  , "description": "duck"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "duck"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦢"
+  , "description": "swan"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "swan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦉"
+  , "description": "owl"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "owl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦤"
+  , "description": "dodo"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "dodo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🪶"
+  , "description": "feather"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "feather"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🦩"
+  , "description": "flamingo"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "flamingo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🦚"
+  , "description": "peacock"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "peacock"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦜"
+  , "description": "parrot"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "parrot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🐸"
+  , "description": "frog"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "frog"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐊"
+  , "description": "crocodile"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "crocodile"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐢"
+  , "description": "turtle"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "turtle"
+    ]
+  , "tags": [
+      "slow"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦎"
+  , "description": "lizard"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "lizard"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🐍"
+  , "description": "snake"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "snake"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐲"
+  , "description": "dragon face"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "dragon_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐉"
+  , "description": "dragon"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "dragon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦕"
+  , "description": "sauropod"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "sauropod"
+    ]
+  , "tags": [
+      "dinosaur"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦖"
+  , "description": "T-Rex"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "t-rex"
+    ]
+  , "tags": [
+      "dinosaur"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🐳"
+  , "description": "spouting whale"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "whale"
+    ]
+  , "tags": [
+      "sea"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐋"
+  , "description": "whale"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "whale2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐬"
+  , "description": "dolphin"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "dolphin"
+    , "flipper"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦭"
+  , "description": "seal"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "seal"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🐟"
+  , "description": "fish"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "fish"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐠"
+  , "description": "tropical fish"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "tropical_fish"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐡"
+  , "description": "blowfish"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "blowfish"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦈"
+  , "description": "shark"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "shark"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🐙"
+  , "description": "octopus"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "octopus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐚"
+  , "description": "spiral shell"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "shell"
+    ]
+  , "tags": [
+      "sea"
+    , "beach"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐌"
+  , "description": "snail"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "snail"
+    ]
+  , "tags": [
+      "slow"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦋"
+  , "description": "butterfly"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "butterfly"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🐛"
+  , "description": "bug"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "bug"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐜"
+  , "description": "ant"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "ant"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🐝"
+  , "description": "honeybee"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "bee"
+    , "honeybee"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪲"
+  , "description": "beetle"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "beetle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🐞"
+  , "description": "lady beetle"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "lady_beetle"
+    ]
+  , "tags": [
+      "bug"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🦗"
+  , "description": "cricket"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "cricket"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🪳"
+  , "description": "cockroach"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "cockroach"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🕷️"
+  , "description": "spider"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "spider"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🕸️"
+  , "description": "spider web"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "spider_web"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🦂"
+  , "description": "scorpion"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "scorpion"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🦟"
+  , "description": "mosquito"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "mosquito"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🪰"
+  , "description": "fly"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "fly"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🪱"
+  , "description": "worm"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "worm"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🦠"
+  , "description": "microbe"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "microbe"
+    ]
+  , "tags": [
+      "germ"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "💐"
+  , "description": "bouquet"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "bouquet"
+    ]
+  , "tags": [
+      "flowers"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌸"
+  , "description": "cherry blossom"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "cherry_blossom"
+    ]
+  , "tags": [
+      "flower"
+    , "spring"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💮"
+  , "description": "white flower"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "white_flower"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏵️"
+  , "description": "rosette"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "rosette"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌹"
+  , "description": "rose"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "rose"
+    ]
+  , "tags": [
+      "flower"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥀"
+  , "description": "wilted flower"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "wilted_flower"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🌺"
+  , "description": "hibiscus"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "hibiscus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌻"
+  , "description": "sunflower"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "sunflower"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌼"
+  , "description": "blossom"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "blossom"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌷"
+  , "description": "tulip"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "tulip"
+    ]
+  , "tags": [
+      "flower"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌱"
+  , "description": "seedling"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "seedling"
+    ]
+  , "tags": [
+      "plant"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪴"
+  , "description": "potted plant"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "potted_plant"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🌲"
+  , "description": "evergreen tree"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "evergreen_tree"
+    ]
+  , "tags": [
+      "wood"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌳"
+  , "description": "deciduous tree"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "deciduous_tree"
+    ]
+  , "tags": [
+      "wood"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌴"
+  , "description": "palm tree"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "palm_tree"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌵"
+  , "description": "cactus"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "cactus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌾"
+  , "description": "sheaf of rice"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "ear_of_rice"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌿"
+  , "description": "herb"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "herb"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "☘️"
+  , "description": "shamrock"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "shamrock"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🍀"
+  , "description": "four leaf clover"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "four_leaf_clover"
+    ]
+  , "tags": [
+      "luck"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍁"
+  , "description": "maple leaf"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "maple_leaf"
+    ]
+  , "tags": [
+      "canada"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍂"
+  , "description": "fallen leaf"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "fallen_leaf"
+    ]
+  , "tags": [
+      "autumn"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍃"
+  , "description": "leaf fluttering in wind"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "leaves"
+    ]
+  , "tags": [
+      "leaf"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍇"
+  , "description": "grapes"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "grapes"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍈"
+  , "description": "melon"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "melon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍉"
+  , "description": "watermelon"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "watermelon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍊"
+  , "description": "tangerine"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "tangerine"
+    , "orange"
+    , "mandarin"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍋"
+  , "description": "lemon"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "lemon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍌"
+  , "description": "banana"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "banana"
+    ]
+  , "tags": [
+      "fruit"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍍"
+  , "description": "pineapple"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "pineapple"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥭"
+  , "description": "mango"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "mango"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🍎"
+  , "description": "red apple"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "apple"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍏"
+  , "description": "green apple"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "green_apple"
+    ]
+  , "tags": [
+      "fruit"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍐"
+  , "description": "pear"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "pear"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍑"
+  , "description": "peach"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "peach"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍒"
+  , "description": "cherries"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "cherries"
+    ]
+  , "tags": [
+      "fruit"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍓"
+  , "description": "strawberry"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "strawberry"
+    ]
+  , "tags": [
+      "fruit"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🫐"
+  , "description": "blueberries"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "blueberries"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🥝"
+  , "description": "kiwi fruit"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "kiwi_fruit"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🍅"
+  , "description": "tomato"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "tomato"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🫒"
+  , "description": "olive"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "olive"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🥥"
+  , "description": "coconut"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "coconut"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥑"
+  , "description": "avocado"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "avocado"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🍆"
+  , "description": "eggplant"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "eggplant"
+    ]
+  , "tags": [
+      "aubergine"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥔"
+  , "description": "potato"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "potato"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥕"
+  , "description": "carrot"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "carrot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🌽"
+  , "description": "ear of corn"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "corn"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌶️"
+  , "description": "hot pepper"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "hot_pepper"
+    ]
+  , "tags": [
+      "spicy"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🫑"
+  , "description": "bell pepper"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "bell_pepper"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🥒"
+  , "description": "cucumber"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "cucumber"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥬"
+  , "description": "leafy green"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "leafy_green"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥦"
+  , "description": "broccoli"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "broccoli"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧄"
+  , "description": "garlic"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "garlic"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🧅"
+  , "description": "onion"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "onion"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🍄"
+  , "description": "mushroom"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "mushroom"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥜"
+  , "description": "peanuts"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "peanuts"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🌰"
+  , "description": "chestnut"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "chestnut"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍞"
+  , "description": "bread"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "bread"
+    ]
+  , "tags": [
+      "toast"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥐"
+  , "description": "croissant"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "croissant"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥖"
+  , "description": "baguette bread"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "baguette_bread"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🫓"
+  , "description": "flatbread"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "flatbread"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🥨"
+  , "description": "pretzel"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "pretzel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥯"
+  , "description": "bagel"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "bagel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥞"
+  , "description": "pancakes"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "pancakes"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🧇"
+  , "description": "waffle"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "waffle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🧀"
+  , "description": "cheese wedge"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "cheese"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🍖"
+  , "description": "meat on bone"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "meat_on_bone"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍗"
+  , "description": "poultry leg"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "poultry_leg"
+    ]
+  , "tags": [
+      "meat"
+    , "chicken"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥩"
+  , "description": "cut of meat"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "cut_of_meat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥓"
+  , "description": "bacon"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "bacon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🍔"
+  , "description": "hamburger"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "hamburger"
+    ]
+  , "tags": [
+      "burger"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍟"
+  , "description": "french fries"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "fries"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍕"
+  , "description": "pizza"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "pizza"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌭"
+  , "description": "hot dog"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "hotdog"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🥪"
+  , "description": "sandwich"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "sandwich"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🌮"
+  , "description": "taco"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "taco"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌯"
+  , "description": "burrito"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "burrito"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🫔"
+  , "description": "tamale"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "tamale"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🥙"
+  , "description": "stuffed flatbread"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "stuffed_flatbread"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🧆"
+  , "description": "falafel"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "falafel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🥚"
+  , "description": "egg"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "egg"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🍳"
+  , "description": "cooking"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "fried_egg"
+    ]
+  , "tags": [
+      "breakfast"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥘"
+  , "description": "shallow pan of food"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "shallow_pan_of_food"
+    ]
+  , "tags": [
+      "paella"
+    , "curry"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🍲"
+  , "description": "pot of food"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "stew"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🫕"
+  , "description": "fondue"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "fondue"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🥣"
+  , "description": "bowl with spoon"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "bowl_with_spoon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥗"
+  , "description": "green salad"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "green_salad"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🍿"
+  , "description": "popcorn"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "popcorn"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🧈"
+  , "description": "butter"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "butter"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🧂"
+  , "description": "salt"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "salt"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥫"
+  , "description": "canned food"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "canned_food"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🍱"
+  , "description": "bento box"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "bento"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍘"
+  , "description": "rice cracker"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "rice_cracker"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍙"
+  , "description": "rice ball"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "rice_ball"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍚"
+  , "description": "cooked rice"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "rice"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍛"
+  , "description": "curry rice"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "curry"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍜"
+  , "description": "steaming bowl"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "ramen"
+    ]
+  , "tags": [
+      "noodle"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍝"
+  , "description": "spaghetti"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "spaghetti"
+    ]
+  , "tags": [
+      "pasta"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍠"
+  , "description": "roasted sweet potato"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "sweet_potato"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍢"
+  , "description": "oden"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "oden"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍣"
+  , "description": "sushi"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "sushi"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍤"
+  , "description": "fried shrimp"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "fried_shrimp"
+    ]
+  , "tags": [
+      "tempura"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍥"
+  , "description": "fish cake with swirl"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "fish_cake"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥮"
+  , "description": "moon cake"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "moon_cake"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🍡"
+  , "description": "dango"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "dango"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥟"
+  , "description": "dumpling"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "dumpling"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥠"
+  , "description": "fortune cookie"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "fortune_cookie"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥡"
+  , "description": "takeout box"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "takeout_box"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦀"
+  , "description": "crab"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "crab"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🦞"
+  , "description": "lobster"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "lobster"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦐"
+  , "description": "shrimp"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "shrimp"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦑"
+  , "description": "squid"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "squid"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦪"
+  , "description": "oyster"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "oyster"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🍦"
+  , "description": "soft ice cream"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "icecream"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍧"
+  , "description": "shaved ice"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "shaved_ice"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍨"
+  , "description": "ice cream"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "ice_cream"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍩"
+  , "description": "doughnut"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "doughnut"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍪"
+  , "description": "cookie"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "cookie"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎂"
+  , "description": "birthday cake"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "birthday"
+    ]
+  , "tags": [
+      "party"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍰"
+  , "description": "shortcake"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "cake"
+    ]
+  , "tags": [
+      "dessert"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧁"
+  , "description": "cupcake"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "cupcake"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥧"
+  , "description": "pie"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "pie"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🍫"
+  , "description": "chocolate bar"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "chocolate_bar"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍬"
+  , "description": "candy"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "candy"
+    ]
+  , "tags": [
+      "sweet"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍭"
+  , "description": "lollipop"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "lollipop"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍮"
+  , "description": "custard"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "custard"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍯"
+  , "description": "honey pot"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "honey_pot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍼"
+  , "description": "baby bottle"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "baby_bottle"
+    ]
+  , "tags": [
+      "milk"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥛"
+  , "description": "glass of milk"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "milk_glass"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "☕"
+  , "description": "hot beverage"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "coffee"
+    ]
+  , "tags": [
+      "cafe"
+    , "espresso"
+    ]
+  , "unicode_version": "4.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🫖"
+  , "description": "teapot"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "teapot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🍵"
+  , "description": "teacup without handle"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "tea"
+    ]
+  , "tags": [
+      "green"
+    , "breakfast"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍶"
+  , "description": "sake"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "sake"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍾"
+  , "description": "bottle with popping cork"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "champagne"
+    ]
+  , "tags": [
+      "bottle"
+    , "bubbly"
+    , "celebration"
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🍷"
+  , "description": "wine glass"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "wine_glass"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍸"
+  , "description": "cocktail glass"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "cocktail"
+    ]
+  , "tags": [
+      "drink"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍹"
+  , "description": "tropical drink"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "tropical_drink"
+    ]
+  , "tags": [
+      "summer"
+    , "vacation"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍺"
+  , "description": "beer mug"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "beer"
+    ]
+  , "tags": [
+      "drink"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍻"
+  , "description": "clinking beer mugs"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "beers"
+    ]
+  , "tags": [
+      "drinks"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥂"
+  , "description": "clinking glasses"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "clinking_glasses"
+    ]
+  , "tags": [
+      "cheers"
+    , "toast"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥃"
+  , "description": "tumbler glass"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "tumbler_glass"
+    ]
+  , "tags": [
+      "whisky"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥤"
+  , "description": "cup with straw"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "cup_with_straw"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧋"
+  , "description": "bubble tea"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "bubble_tea"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🧃"
+  , "description": "beverage box"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "beverage_box"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🧉"
+  , "description": "mate"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "mate"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🧊"
+  , "description": "ice"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "ice_cube"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🥢"
+  , "description": "chopsticks"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "chopsticks"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🍽️"
+  , "description": "fork and knife with plate"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "plate_with_cutlery"
+    ]
+  , "tags": [
+      "dining"
+    , "dinner"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🍴"
+  , "description": "fork and knife"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "fork_and_knife"
+    ]
+  , "tags": [
+      "cutlery"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥄"
+  , "description": "spoon"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "spoon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🔪"
+  , "description": "kitchen knife"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "hocho"
+    , "knife"
+    ]
+  , "tags": [
+      "cut"
+    , "chop"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏺"
+  , "description": "amphora"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "amphora"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌍"
+  , "description": "globe showing Europe-Africa"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "earth_africa"
+    ]
+  , "tags": [
+      "globe"
+    , "world"
+    , "international"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌎"
+  , "description": "globe showing Americas"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "earth_americas"
+    ]
+  , "tags": [
+      "globe"
+    , "world"
+    , "international"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌏"
+  , "description": "globe showing Asia-Australia"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "earth_asia"
+    ]
+  , "tags": [
+      "globe"
+    , "world"
+    , "international"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌐"
+  , "description": "globe with meridians"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "globe_with_meridians"
+    ]
+  , "tags": [
+      "world"
+    , "global"
+    , "international"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🗺️"
+  , "description": "world map"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "world_map"
+    ]
+  , "tags": [
+      "travel"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🗾"
+  , "description": "map of Japan"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "japan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧭"
+  , "description": "compass"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "compass"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🏔️"
+  , "description": "snow-capped mountain"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "mountain_snow"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⛰️"
+  , "description": "mountain"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "mountain"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌋"
+  , "description": "volcano"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "volcano"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🗻"
+  , "description": "mount fuji"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "mount_fuji"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏕️"
+  , "description": "camping"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "camping"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏖️"
+  , "description": "beach with umbrella"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "beach_umbrella"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏜️"
+  , "description": "desert"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "desert"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏝️"
+  , "description": "desert island"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "desert_island"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏞️"
+  , "description": "national park"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "national_park"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏟️"
+  , "description": "stadium"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "stadium"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏛️"
+  , "description": "classical building"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "classical_building"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏗️"
+  , "description": "building construction"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "building_construction"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🧱"
+  , "description": "brick"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "bricks"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🪨"
+  , "description": "rock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "rock"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🪵"
+  , "description": "wood"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "wood"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🛖"
+  , "description": "hut"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "hut"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🏘️"
+  , "description": "houses"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "houses"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏚️"
+  , "description": "derelict house"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "derelict_house"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏠"
+  , "description": "house"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "house"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏡"
+  , "description": "house with garden"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "house_with_garden"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏢"
+  , "description": "office building"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "office"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏣"
+  , "description": "Japanese post office"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "post_office"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏤"
+  , "description": "post office"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "european_post_office"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏥"
+  , "description": "hospital"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "hospital"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏦"
+  , "description": "bank"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "bank"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏨"
+  , "description": "hotel"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "hotel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏩"
+  , "description": "love hotel"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "love_hotel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏪"
+  , "description": "convenience store"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "convenience_store"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏫"
+  , "description": "school"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "school"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏬"
+  , "description": "department store"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "department_store"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏭"
+  , "description": "factory"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "factory"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏯"
+  , "description": "Japanese castle"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "japanese_castle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏰"
+  , "description": "castle"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "european_castle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💒"
+  , "description": "wedding"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "wedding"
+    ]
+  , "tags": [
+      "marriage"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🗼"
+  , "description": "Tokyo tower"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "tokyo_tower"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🗽"
+  , "description": "Statue of Liberty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "statue_of_liberty"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⛪"
+  , "description": "church"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "church"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕌"
+  , "description": "mosque"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "mosque"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛕"
+  , "description": "hindu temple"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "hindu_temple"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🕍"
+  , "description": "synagogue"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "synagogue"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⛩️"
+  , "description": "shinto shrine"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "shinto_shrine"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🕋"
+  , "description": "kaaba"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "kaaba"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⛲"
+  , "description": "fountain"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "fountain"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⛺"
+  , "description": "tent"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "tent"
+    ]
+  , "tags": [
+      "camping"
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌁"
+  , "description": "foggy"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "foggy"
+    ]
+  , "tags": [
+      "karl"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌃"
+  , "description": "night with stars"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "night_with_stars"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏙️"
+  , "description": "cityscape"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "cityscape"
+    ]
+  , "tags": [
+      "skyline"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌄"
+  , "description": "sunrise over mountains"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "sunrise_over_mountains"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌅"
+  , "description": "sunrise"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "sunrise"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌆"
+  , "description": "cityscape at dusk"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "city_sunset"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌇"
+  , "description": "sunset"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "city_sunrise"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌉"
+  , "description": "bridge at night"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "bridge_at_night"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♨️"
+  , "description": "hot springs"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "hotsprings"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎠"
+  , "description": "carousel horse"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "carousel_horse"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎡"
+  , "description": "ferris wheel"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "ferris_wheel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎢"
+  , "description": "roller coaster"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "roller_coaster"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💈"
+  , "description": "barber pole"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "barber"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎪"
+  , "description": "circus tent"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "circus_tent"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚂"
+  , "description": "locomotive"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "steam_locomotive"
+    ]
+  , "tags": [
+      "train"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚃"
+  , "description": "railway car"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "railway_car"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚄"
+  , "description": "high-speed train"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "bullettrain_side"
+    ]
+  , "tags": [
+      "train"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚅"
+  , "description": "bullet train"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "bullettrain_front"
+    ]
+  , "tags": [
+      "train"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚆"
+  , "description": "train"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "train2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚇"
+  , "description": "metro"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "metro"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚈"
+  , "description": "light rail"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "light_rail"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚉"
+  , "description": "station"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "station"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚊"
+  , "description": "tram"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "tram"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚝"
+  , "description": "monorail"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "monorail"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚞"
+  , "description": "mountain railway"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "mountain_railway"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚋"
+  , "description": "tram car"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "train"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚌"
+  , "description": "bus"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "bus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚍"
+  , "description": "oncoming bus"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "oncoming_bus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚎"
+  , "description": "trolleybus"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "trolleybus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚐"
+  , "description": "minibus"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "minibus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚑"
+  , "description": "ambulance"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "ambulance"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚒"
+  , "description": "fire engine"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "fire_engine"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚓"
+  , "description": "police car"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "police_car"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚔"
+  , "description": "oncoming police car"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "oncoming_police_car"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚕"
+  , "description": "taxi"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "taxi"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚖"
+  , "description": "oncoming taxi"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "oncoming_taxi"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚗"
+  , "description": "automobile"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "car"
+    , "red_car"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚘"
+  , "description": "oncoming automobile"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "oncoming_automobile"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚙"
+  , "description": "sport utility vehicle"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "blue_car"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛻"
+  , "description": "pickup truck"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "pickup_truck"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🚚"
+  , "description": "delivery truck"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "truck"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚛"
+  , "description": "articulated lorry"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "articulated_lorry"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚜"
+  , "description": "tractor"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "tractor"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏎️"
+  , "description": "racing car"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "racing_car"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏍️"
+  , "description": "motorcycle"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "motorcycle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛵"
+  , "description": "motor scooter"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "motor_scooter"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦽"
+  , "description": "manual wheelchair"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "manual_wheelchair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🦼"
+  , "description": "motorized wheelchair"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "motorized_wheelchair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🛺"
+  , "description": "auto rickshaw"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "auto_rickshaw"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🚲"
+  , "description": "bicycle"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "bike"
+    ]
+  , "tags": [
+      "bicycle"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛴"
+  , "description": "kick scooter"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "kick_scooter"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🛹"
+  , "description": "skateboard"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "skateboard"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🛼"
+  , "description": "roller skate"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "roller_skate"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🚏"
+  , "description": "bus stop"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "busstop"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛣️"
+  , "description": "motorway"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "motorway"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛤️"
+  , "description": "railway track"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "railway_track"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛢️"
+  , "description": "oil drum"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "oil_drum"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⛽"
+  , "description": "fuel pump"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "fuelpump"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚨"
+  , "description": "police car light"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "rotating_light"
+    ]
+  , "tags": [
+      "911"
+    , "emergency"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚥"
+  , "description": "horizontal traffic light"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "traffic_light"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚦"
+  , "description": "vertical traffic light"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "vertical_traffic_light"
+    ]
+  , "tags": [
+      "semaphore"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛑"
+  , "description": "stop sign"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "stop_sign"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🚧"
+  , "description": "construction"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "construction"
+    ]
+  , "tags": [
+      "wip"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⚓"
+  , "description": "anchor"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "anchor"
+    ]
+  , "tags": [
+      "ship"
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⛵"
+  , "description": "sailboat"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "boat"
+    , "sailboat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛶"
+  , "description": "canoe"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "canoe"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🚤"
+  , "description": "speedboat"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "speedboat"
+    ]
+  , "tags": [
+      "ship"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛳️"
+  , "description": "passenger ship"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "passenger_ship"
+    ]
+  , "tags": [
+      "cruise"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⛴️"
+  , "description": "ferry"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "ferry"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛥️"
+  , "description": "motor boat"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "motor_boat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🚢"
+  , "description": "ship"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "ship"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "✈️"
+  , "description": "airplane"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "airplane"
+    ]
+  , "tags": [
+      "flight"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛩️"
+  , "description": "small airplane"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "small_airplane"
+    ]
+  , "tags": [
+      "flight"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛫"
+  , "description": "airplane departure"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "flight_departure"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛬"
+  , "description": "airplane arrival"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "flight_arrival"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🪂"
+  , "description": "parachute"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "parachute"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "💺"
+  , "description": "seat"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "seat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚁"
+  , "description": "helicopter"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "helicopter"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚟"
+  , "description": "suspension railway"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "suspension_railway"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚠"
+  , "description": "mountain cableway"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "mountain_cableway"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚡"
+  , "description": "aerial tramway"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "aerial_tramway"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛰️"
+  , "description": "satellite"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "artificial_satellite"
+    ]
+  , "tags": [
+      "orbit"
+    , "space"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🚀"
+  , "description": "rocket"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "rocket"
+    ]
+  , "tags": [
+      "ship"
+    , "launch"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛸"
+  , "description": "flying saucer"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "flying_saucer"
+    ]
+  , "tags": [
+      "ufo"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🛎️"
+  , "description": "bellhop bell"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "bellhop_bell"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🧳"
+  , "description": "luggage"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "luggage"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "⌛"
+  , "description": "hourglass done"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "hourglass"
+    ]
+  , "tags": [
+      "time"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⏳"
+  , "description": "hourglass not done"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "hourglass_flowing_sand"
+    ]
+  , "tags": [
+      "time"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⌚"
+  , "description": "watch"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "watch"
+    ]
+  , "tags": [
+      "time"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⏰"
+  , "description": "alarm clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "alarm_clock"
+    ]
+  , "tags": [
+      "morning"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⏱️"
+  , "description": "stopwatch"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "stopwatch"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⏲️"
+  , "description": "timer clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "timer_clock"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🕰️"
+  , "description": "mantelpiece clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "mantelpiece_clock"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🕛"
+  , "description": "twelve o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock12"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕧"
+  , "description": "twelve-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock1230"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕐"
+  , "description": "one o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock1"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕜"
+  , "description": "one-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock130"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕑"
+  , "description": "two o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕝"
+  , "description": "two-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock230"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕒"
+  , "description": "three o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock3"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕞"
+  , "description": "three-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock330"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕓"
+  , "description": "four o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock4"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕟"
+  , "description": "four-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock430"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕔"
+  , "description": "five o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock5"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕠"
+  , "description": "five-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock530"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕕"
+  , "description": "six o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock6"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕡"
+  , "description": "six-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock630"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕖"
+  , "description": "seven o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock7"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕢"
+  , "description": "seven-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock730"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕗"
+  , "description": "eight o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock8"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕣"
+  , "description": "eight-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock830"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕘"
+  , "description": "nine o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock9"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕤"
+  , "description": "nine-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock930"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕙"
+  , "description": "ten o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock10"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕥"
+  , "description": "ten-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock1030"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕚"
+  , "description": "eleven o’clock"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock11"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕦"
+  , "description": "eleven-thirty"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "clock1130"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌑"
+  , "description": "new moon"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "new_moon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌒"
+  , "description": "waxing crescent moon"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "waxing_crescent_moon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌓"
+  , "description": "first quarter moon"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "first_quarter_moon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌔"
+  , "description": "waxing gibbous moon"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "moon"
+    , "waxing_gibbous_moon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌕"
+  , "description": "full moon"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "full_moon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌖"
+  , "description": "waning gibbous moon"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "waning_gibbous_moon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌗"
+  , "description": "last quarter moon"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "last_quarter_moon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌘"
+  , "description": "waning crescent moon"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "waning_crescent_moon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌙"
+  , "description": "crescent moon"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "crescent_moon"
+    ]
+  , "tags": [
+      "night"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌚"
+  , "description": "new moon face"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "new_moon_with_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌛"
+  , "description": "first quarter moon face"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "first_quarter_moon_with_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌜"
+  , "description": "last quarter moon face"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "last_quarter_moon_with_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌡️"
+  , "description": "thermometer"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "thermometer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "☀️"
+  , "description": "sun"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "sunny"
+    ]
+  , "tags": [
+      "weather"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌝"
+  , "description": "full moon face"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "full_moon_with_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌞"
+  , "description": "sun with face"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "sun_with_face"
+    ]
+  , "tags": [
+      "summer"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪐"
+  , "description": "ringed planet"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "ringed_planet"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "⭐"
+  , "description": "star"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "star"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌟"
+  , "description": "glowing star"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "star2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌠"
+  , "description": "shooting star"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "stars"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌌"
+  , "description": "milky way"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "milky_way"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "☁️"
+  , "description": "cloud"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "cloud"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⛅"
+  , "description": "sun behind cloud"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "partly_sunny"
+    ]
+  , "tags": [
+      "weather"
+    , "cloud"
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⛈️"
+  , "description": "cloud with lightning and rain"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "cloud_with_lightning_and_rain"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌤️"
+  , "description": "sun behind small cloud"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "sun_behind_small_cloud"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌥️"
+  , "description": "sun behind large cloud"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "sun_behind_large_cloud"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌦️"
+  , "description": "sun behind rain cloud"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "sun_behind_rain_cloud"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌧️"
+  , "description": "cloud with rain"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "cloud_with_rain"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌨️"
+  , "description": "cloud with snow"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "cloud_with_snow"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌩️"
+  , "description": "cloud with lightning"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "cloud_with_lightning"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌪️"
+  , "description": "tornado"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "tornado"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌫️"
+  , "description": "fog"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "fog"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌬️"
+  , "description": "wind face"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "wind_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🌀"
+  , "description": "cyclone"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "cyclone"
+    ]
+  , "tags": [
+      "swirl"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌈"
+  , "description": "rainbow"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "rainbow"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌂"
+  , "description": "closed umbrella"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "closed_umbrella"
+    ]
+  , "tags": [
+      "weather"
+    , "rain"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "☂️"
+  , "description": "umbrella"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "open_umbrella"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "☔"
+  , "description": "umbrella with rain drops"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "umbrella"
+    ]
+  , "tags": [
+      "rain"
+    , "weather"
+    ]
+  , "unicode_version": "4.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⛱️"
+  , "description": "umbrella on ground"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "parasol_on_ground"
+    ]
+  , "tags": [
+      "beach_umbrella"
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⚡"
+  , "description": "high voltage"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "zap"
+    ]
+  , "tags": [
+      "lightning"
+    , "thunder"
+    ]
+  , "unicode_version": "4.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "❄️"
+  , "description": "snowflake"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "snowflake"
+    ]
+  , "tags": [
+      "winter"
+    , "cold"
+    , "weather"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "☃️"
+  , "description": "snowman"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "snowman_with_snow"
+    ]
+  , "tags": [
+      "winter"
+    , "christmas"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⛄"
+  , "description": "snowman without snow"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "snowman"
+    ]
+  , "tags": [
+      "winter"
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "☄️"
+  , "description": "comet"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "comet"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🔥"
+  , "description": "fire"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "fire"
+    ]
+  , "tags": [
+      "burn"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💧"
+  , "description": "droplet"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "droplet"
+    ]
+  , "tags": [
+      "water"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🌊"
+  , "description": "water wave"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "ocean"
+    ]
+  , "tags": [
+      "sea"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎃"
+  , "description": "jack-o-lantern"
+  , "category": "Activities"
+  , "aliases": [
+      "jack_o_lantern"
+    ]
+  , "tags": [
+      "halloween"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎄"
+  , "description": "Christmas tree"
+  , "category": "Activities"
+  , "aliases": [
+      "christmas_tree"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎆"
+  , "description": "fireworks"
+  , "category": "Activities"
+  , "aliases": [
+      "fireworks"
+    ]
+  , "tags": [
+      "festival"
+    , "celebration"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎇"
+  , "description": "sparkler"
+  , "category": "Activities"
+  , "aliases": [
+      "sparkler"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧨"
+  , "description": "firecracker"
+  , "category": "Activities"
+  , "aliases": [
+      "firecracker"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "✨"
+  , "description": "sparkles"
+  , "category": "Activities"
+  , "aliases": [
+      "sparkles"
+    ]
+  , "tags": [
+      "shiny"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎈"
+  , "description": "balloon"
+  , "category": "Activities"
+  , "aliases": [
+      "balloon"
+    ]
+  , "tags": [
+      "party"
+    , "birthday"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎉"
+  , "description": "party popper"
+  , "category": "Activities"
+  , "aliases": [
+      "tada"
+    ]
+  , "tags": [
+      "hooray"
+    , "party"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎊"
+  , "description": "confetti ball"
+  , "category": "Activities"
+  , "aliases": [
+      "confetti_ball"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎋"
+  , "description": "tanabata tree"
+  , "category": "Activities"
+  , "aliases": [
+      "tanabata_tree"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎍"
+  , "description": "pine decoration"
+  , "category": "Activities"
+  , "aliases": [
+      "bamboo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎎"
+  , "description": "Japanese dolls"
+  , "category": "Activities"
+  , "aliases": [
+      "dolls"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎏"
+  , "description": "carp streamer"
+  , "category": "Activities"
+  , "aliases": [
+      "flags"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎐"
+  , "description": "wind chime"
+  , "category": "Activities"
+  , "aliases": [
+      "wind_chime"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎑"
+  , "description": "moon viewing ceremony"
+  , "category": "Activities"
+  , "aliases": [
+      "rice_scene"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧧"
+  , "description": "red envelope"
+  , "category": "Activities"
+  , "aliases": [
+      "red_envelope"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🎀"
+  , "description": "ribbon"
+  , "category": "Activities"
+  , "aliases": [
+      "ribbon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎁"
+  , "description": "wrapped gift"
+  , "category": "Activities"
+  , "aliases": [
+      "gift"
+    ]
+  , "tags": [
+      "present"
+    , "birthday"
+    , "christmas"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎗️"
+  , "description": "reminder ribbon"
+  , "category": "Activities"
+  , "aliases": [
+      "reminder_ribbon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🎟️"
+  , "description": "admission tickets"
+  , "category": "Activities"
+  , "aliases": [
+      "tickets"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🎫"
+  , "description": "ticket"
+  , "category": "Activities"
+  , "aliases": [
+      "ticket"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎖️"
+  , "description": "military medal"
+  , "category": "Activities"
+  , "aliases": [
+      "medal_military"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏆"
+  , "description": "trophy"
+  , "category": "Activities"
+  , "aliases": [
+      "trophy"
+    ]
+  , "tags": [
+      "award"
+    , "contest"
+    , "winner"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏅"
+  , "description": "sports medal"
+  , "category": "Activities"
+  , "aliases": [
+      "medal_sports"
+    ]
+  , "tags": [
+      "gold"
+    , "winner"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🥇"
+  , "description": "1st place medal"
+  , "category": "Activities"
+  , "aliases": [
+      "1st_place_medal"
+    ]
+  , "tags": [
+      "gold"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥈"
+  , "description": "2nd place medal"
+  , "category": "Activities"
+  , "aliases": [
+      "2nd_place_medal"
+    ]
+  , "tags": [
+      "silver"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥉"
+  , "description": "3rd place medal"
+  , "category": "Activities"
+  , "aliases": [
+      "3rd_place_medal"
+    ]
+  , "tags": [
+      "bronze"
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "⚽"
+  , "description": "soccer ball"
+  , "category": "Activities"
+  , "aliases": [
+      "soccer"
+    ]
+  , "tags": [
+      "sports"
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⚾"
+  , "description": "baseball"
+  , "category": "Activities"
+  , "aliases": [
+      "baseball"
+    ]
+  , "tags": [
+      "sports"
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥎"
+  , "description": "softball"
+  , "category": "Activities"
+  , "aliases": [
+      "softball"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🏀"
+  , "description": "basketball"
+  , "category": "Activities"
+  , "aliases": [
+      "basketball"
+    ]
+  , "tags": [
+      "sports"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏐"
+  , "description": "volleyball"
+  , "category": "Activities"
+  , "aliases": [
+      "volleyball"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏈"
+  , "description": "american football"
+  , "category": "Activities"
+  , "aliases": [
+      "football"
+    ]
+  , "tags": [
+      "sports"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏉"
+  , "description": "rugby football"
+  , "category": "Activities"
+  , "aliases": [
+      "rugby_football"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎾"
+  , "description": "tennis"
+  , "category": "Activities"
+  , "aliases": [
+      "tennis"
+    ]
+  , "tags": [
+      "sports"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥏"
+  , "description": "flying disc"
+  , "category": "Activities"
+  , "aliases": [
+      "flying_disc"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🎳"
+  , "description": "bowling"
+  , "category": "Activities"
+  , "aliases": [
+      "bowling"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏏"
+  , "description": "cricket game"
+  , "category": "Activities"
+  , "aliases": [
+      "cricket_game"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏑"
+  , "description": "field hockey"
+  , "category": "Activities"
+  , "aliases": [
+      "field_hockey"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏒"
+  , "description": "ice hockey"
+  , "category": "Activities"
+  , "aliases": [
+      "ice_hockey"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🥍"
+  , "description": "lacrosse"
+  , "category": "Activities"
+  , "aliases": [
+      "lacrosse"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🏓"
+  , "description": "ping pong"
+  , "category": "Activities"
+  , "aliases": [
+      "ping_pong"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏸"
+  , "description": "badminton"
+  , "category": "Activities"
+  , "aliases": [
+      "badminton"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🥊"
+  , "description": "boxing glove"
+  , "category": "Activities"
+  , "aliases": [
+      "boxing_glove"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥋"
+  , "description": "martial arts uniform"
+  , "category": "Activities"
+  , "aliases": [
+      "martial_arts_uniform"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🥅"
+  , "description": "goal net"
+  , "category": "Activities"
+  , "aliases": [
+      "goal_net"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "⛳"
+  , "description": "flag in hole"
+  , "category": "Activities"
+  , "aliases": [
+      "golf"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⛸️"
+  , "description": "ice skate"
+  , "category": "Activities"
+  , "aliases": [
+      "ice_skate"
+    ]
+  , "tags": [
+      "skating"
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🎣"
+  , "description": "fishing pole"
+  , "category": "Activities"
+  , "aliases": [
+      "fishing_pole_and_fish"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🤿"
+  , "description": "diving mask"
+  , "category": "Activities"
+  , "aliases": [
+      "diving_mask"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🎽"
+  , "description": "running shirt"
+  , "category": "Activities"
+  , "aliases": [
+      "running_shirt_with_sash"
+    ]
+  , "tags": [
+      "marathon"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎿"
+  , "description": "skis"
+  , "category": "Activities"
+  , "aliases": [
+      "ski"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛷"
+  , "description": "sled"
+  , "category": "Activities"
+  , "aliases": [
+      "sled"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥌"
+  , "description": "curling stone"
+  , "category": "Activities"
+  , "aliases": [
+      "curling_stone"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🎯"
+  , "description": "direct hit"
+  , "category": "Activities"
+  , "aliases": [
+      "dart"
+    ]
+  , "tags": [
+      "target"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪀"
+  , "description": "yo-yo"
+  , "category": "Activities"
+  , "aliases": [
+      "yo_yo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🪁"
+  , "description": "kite"
+  , "category": "Activities"
+  , "aliases": [
+      "kite"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🎱"
+  , "description": "pool 8 ball"
+  , "category": "Activities"
+  , "aliases": [
+      "8ball"
+    ]
+  , "tags": [
+      "pool"
+    , "billiards"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔮"
+  , "description": "crystal ball"
+  , "category": "Activities"
+  , "aliases": [
+      "crystal_ball"
+    ]
+  , "tags": [
+      "fortune"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪄"
+  , "description": "magic wand"
+  , "category": "Activities"
+  , "aliases": [
+      "magic_wand"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🧿"
+  , "description": "nazar amulet"
+  , "category": "Activities"
+  , "aliases": [
+      "nazar_amulet"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🎮"
+  , "description": "video game"
+  , "category": "Activities"
+  , "aliases": [
+      "video_game"
+    ]
+  , "tags": [
+      "play"
+    , "controller"
+    , "console"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕹️"
+  , "description": "joystick"
+  , "category": "Activities"
+  , "aliases": [
+      "joystick"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🎰"
+  , "description": "slot machine"
+  , "category": "Activities"
+  , "aliases": [
+      "slot_machine"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎲"
+  , "description": "game die"
+  , "category": "Activities"
+  , "aliases": [
+      "game_die"
+    ]
+  , "tags": [
+      "dice"
+    , "gambling"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧩"
+  , "description": "puzzle piece"
+  , "category": "Activities"
+  , "aliases": [
+      "jigsaw"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧸"
+  , "description": "teddy bear"
+  , "category": "Activities"
+  , "aliases": [
+      "teddy_bear"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🪅"
+  , "description": "piñata"
+  , "category": "Activities"
+  , "aliases": [
+      "pinata"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🪆"
+  , "description": "nesting dolls"
+  , "category": "Activities"
+  , "aliases": [
+      "nesting_dolls"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "♠️"
+  , "description": "spade suit"
+  , "category": "Activities"
+  , "aliases": [
+      "spades"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♥️"
+  , "description": "heart suit"
+  , "category": "Activities"
+  , "aliases": [
+      "hearts"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♦️"
+  , "description": "diamond suit"
+  , "category": "Activities"
+  , "aliases": [
+      "diamonds"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♣️"
+  , "description": "club suit"
+  , "category": "Activities"
+  , "aliases": [
+      "clubs"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♟️"
+  , "description": "chess pawn"
+  , "category": "Activities"
+  , "aliases": [
+      "chess_pawn"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🃏"
+  , "description": "joker"
+  , "category": "Activities"
+  , "aliases": [
+      "black_joker"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🀄"
+  , "description": "mahjong red dragon"
+  , "category": "Activities"
+  , "aliases": [
+      "mahjong"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎴"
+  , "description": "flower playing cards"
+  , "category": "Activities"
+  , "aliases": [
+      "flower_playing_cards"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎭"
+  , "description": "performing arts"
+  , "category": "Activities"
+  , "aliases": [
+      "performing_arts"
+    ]
+  , "tags": [
+      "theater"
+    , "drama"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🖼️"
+  , "description": "framed picture"
+  , "category": "Activities"
+  , "aliases": [
+      "framed_picture"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🎨"
+  , "description": "artist palette"
+  , "category": "Activities"
+  , "aliases": [
+      "art"
+    ]
+  , "tags": [
+      "design"
+    , "paint"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧵"
+  , "description": "thread"
+  , "category": "Activities"
+  , "aliases": [
+      "thread"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🪡"
+  , "description": "sewing needle"
+  , "category": "Activities"
+  , "aliases": [
+      "sewing_needle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🧶"
+  , "description": "yarn"
+  , "category": "Activities"
+  , "aliases": [
+      "yarn"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🪢"
+  , "description": "knot"
+  , "category": "Activities"
+  , "aliases": [
+      "knot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "👓"
+  , "description": "glasses"
+  , "category": "Objects"
+  , "aliases": [
+      "eyeglasses"
+    ]
+  , "tags": [
+      "glasses"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕶️"
+  , "description": "sunglasses"
+  , "category": "Objects"
+  , "aliases": [
+      "dark_sunglasses"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🥽"
+  , "description": "goggles"
+  , "category": "Objects"
+  , "aliases": [
+      "goggles"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥼"
+  , "description": "lab coat"
+  , "category": "Objects"
+  , "aliases": [
+      "lab_coat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦺"
+  , "description": "safety vest"
+  , "category": "Objects"
+  , "aliases": [
+      "safety_vest"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "👔"
+  , "description": "necktie"
+  , "category": "Objects"
+  , "aliases": [
+      "necktie"
+    ]
+  , "tags": [
+      "shirt"
+    , "formal"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👕"
+  , "description": "t-shirt"
+  , "category": "Objects"
+  , "aliases": [
+      "shirt"
+    , "tshirt"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👖"
+  , "description": "jeans"
+  , "category": "Objects"
+  , "aliases": [
+      "jeans"
+    ]
+  , "tags": [
+      "pants"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧣"
+  , "description": "scarf"
+  , "category": "Objects"
+  , "aliases": [
+      "scarf"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧤"
+  , "description": "gloves"
+  , "category": "Objects"
+  , "aliases": [
+      "gloves"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧥"
+  , "description": "coat"
+  , "category": "Objects"
+  , "aliases": [
+      "coat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧦"
+  , "description": "socks"
+  , "category": "Objects"
+  , "aliases": [
+      "socks"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "👗"
+  , "description": "dress"
+  , "category": "Objects"
+  , "aliases": [
+      "dress"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👘"
+  , "description": "kimono"
+  , "category": "Objects"
+  , "aliases": [
+      "kimono"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥻"
+  , "description": "sari"
+  , "category": "Objects"
+  , "aliases": [
+      "sari"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🩱"
+  , "description": "one-piece swimsuit"
+  , "category": "Objects"
+  , "aliases": [
+      "one_piece_swimsuit"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🩲"
+  , "description": "briefs"
+  , "category": "Objects"
+  , "aliases": [
+      "swim_brief"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🩳"
+  , "description": "shorts"
+  , "category": "Objects"
+  , "aliases": [
+      "shorts"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "👙"
+  , "description": "bikini"
+  , "category": "Objects"
+  , "aliases": [
+      "bikini"
+    ]
+  , "tags": [
+      "beach"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👚"
+  , "description": "woman’s clothes"
+  , "category": "Objects"
+  , "aliases": [
+      "womans_clothes"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👛"
+  , "description": "purse"
+  , "category": "Objects"
+  , "aliases": [
+      "purse"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👜"
+  , "description": "handbag"
+  , "category": "Objects"
+  , "aliases": [
+      "handbag"
+    ]
+  , "tags": [
+      "bag"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👝"
+  , "description": "clutch bag"
+  , "category": "Objects"
+  , "aliases": [
+      "pouch"
+    ]
+  , "tags": [
+      "bag"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛍️"
+  , "description": "shopping bags"
+  , "category": "Objects"
+  , "aliases": [
+      "shopping"
+    ]
+  , "tags": [
+      "bags"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🎒"
+  , "description": "backpack"
+  , "category": "Objects"
+  , "aliases": [
+      "school_satchel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🩴"
+  , "description": "thong sandal"
+  , "category": "Objects"
+  , "aliases": [
+      "thong_sandal"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "👞"
+  , "description": "man’s shoe"
+  , "category": "Objects"
+  , "aliases": [
+      "mans_shoe"
+    , "shoe"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👟"
+  , "description": "running shoe"
+  , "category": "Objects"
+  , "aliases": [
+      "athletic_shoe"
+    ]
+  , "tags": [
+      "sneaker"
+    , "sport"
+    , "running"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🥾"
+  , "description": "hiking boot"
+  , "category": "Objects"
+  , "aliases": [
+      "hiking_boot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🥿"
+  , "description": "flat shoe"
+  , "category": "Objects"
+  , "aliases": [
+      "flat_shoe"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "👠"
+  , "description": "high-heeled shoe"
+  , "category": "Objects"
+  , "aliases": [
+      "high_heel"
+    ]
+  , "tags": [
+      "shoe"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👡"
+  , "description": "woman’s sandal"
+  , "category": "Objects"
+  , "aliases": [
+      "sandal"
+    ]
+  , "tags": [
+      "shoe"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🩰"
+  , "description": "ballet shoes"
+  , "category": "Objects"
+  , "aliases": [
+      "ballet_shoes"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "👢"
+  , "description": "woman’s boot"
+  , "category": "Objects"
+  , "aliases": [
+      "boot"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👑"
+  , "description": "crown"
+  , "category": "Objects"
+  , "aliases": [
+      "crown"
+    ]
+  , "tags": [
+      "king"
+    , "queen"
+    , "royal"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "👒"
+  , "description": "woman’s hat"
+  , "category": "Objects"
+  , "aliases": [
+      "womans_hat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎩"
+  , "description": "top hat"
+  , "category": "Objects"
+  , "aliases": [
+      "tophat"
+    ]
+  , "tags": [
+      "hat"
+    , "classy"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎓"
+  , "description": "graduation cap"
+  , "category": "Objects"
+  , "aliases": [
+      "mortar_board"
+    ]
+  , "tags": [
+      "education"
+    , "college"
+    , "university"
+    , "graduation"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧢"
+  , "description": "billed cap"
+  , "category": "Objects"
+  , "aliases": [
+      "billed_cap"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🪖"
+  , "description": "military helmet"
+  , "category": "Objects"
+  , "aliases": [
+      "military_helmet"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "⛑️"
+  , "description": "rescue worker’s helmet"
+  , "category": "Objects"
+  , "aliases": [
+      "rescue_worker_helmet"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "📿"
+  , "description": "prayer beads"
+  , "category": "Objects"
+  , "aliases": [
+      "prayer_beads"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "💄"
+  , "description": "lipstick"
+  , "category": "Objects"
+  , "aliases": [
+      "lipstick"
+    ]
+  , "tags": [
+      "makeup"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💍"
+  , "description": "ring"
+  , "category": "Objects"
+  , "aliases": [
+      "ring"
+    ]
+  , "tags": [
+      "wedding"
+    , "marriage"
+    , "engaged"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💎"
+  , "description": "gem stone"
+  , "category": "Objects"
+  , "aliases": [
+      "gem"
+    ]
+  , "tags": [
+      "diamond"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔇"
+  , "description": "muted speaker"
+  , "category": "Objects"
+  , "aliases": [
+      "mute"
+    ]
+  , "tags": [
+      "sound"
+    , "volume"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔈"
+  , "description": "speaker low volume"
+  , "category": "Objects"
+  , "aliases": [
+      "speaker"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔉"
+  , "description": "speaker medium volume"
+  , "category": "Objects"
+  , "aliases": [
+      "sound"
+    ]
+  , "tags": [
+      "volume"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔊"
+  , "description": "speaker high volume"
+  , "category": "Objects"
+  , "aliases": [
+      "loud_sound"
+    ]
+  , "tags": [
+      "volume"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📢"
+  , "description": "loudspeaker"
+  , "category": "Objects"
+  , "aliases": [
+      "loudspeaker"
+    ]
+  , "tags": [
+      "announcement"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📣"
+  , "description": "megaphone"
+  , "category": "Objects"
+  , "aliases": [
+      "mega"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📯"
+  , "description": "postal horn"
+  , "category": "Objects"
+  , "aliases": [
+      "postal_horn"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔔"
+  , "description": "bell"
+  , "category": "Objects"
+  , "aliases": [
+      "bell"
+    ]
+  , "tags": [
+      "sound"
+    , "notification"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔕"
+  , "description": "bell with slash"
+  , "category": "Objects"
+  , "aliases": [
+      "no_bell"
+    ]
+  , "tags": [
+      "volume"
+    , "off"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎼"
+  , "description": "musical score"
+  , "category": "Objects"
+  , "aliases": [
+      "musical_score"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎵"
+  , "description": "musical note"
+  , "category": "Objects"
+  , "aliases": [
+      "musical_note"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎶"
+  , "description": "musical notes"
+  , "category": "Objects"
+  , "aliases": [
+      "notes"
+    ]
+  , "tags": [
+      "music"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎙️"
+  , "description": "studio microphone"
+  , "category": "Objects"
+  , "aliases": [
+      "studio_microphone"
+    ]
+  , "tags": [
+      "podcast"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🎚️"
+  , "description": "level slider"
+  , "category": "Objects"
+  , "aliases": [
+      "level_slider"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🎛️"
+  , "description": "control knobs"
+  , "category": "Objects"
+  , "aliases": [
+      "control_knobs"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🎤"
+  , "description": "microphone"
+  , "category": "Objects"
+  , "aliases": [
+      "microphone"
+    ]
+  , "tags": [
+      "sing"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎧"
+  , "description": "headphone"
+  , "category": "Objects"
+  , "aliases": [
+      "headphones"
+    ]
+  , "tags": [
+      "music"
+    , "earphones"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📻"
+  , "description": "radio"
+  , "category": "Objects"
+  , "aliases": [
+      "radio"
+    ]
+  , "tags": [
+      "podcast"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎷"
+  , "description": "saxophone"
+  , "category": "Objects"
+  , "aliases": [
+      "saxophone"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪗"
+  , "description": "accordion"
+  , "category": "Objects"
+  , "aliases": [
+      "accordion"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🎸"
+  , "description": "guitar"
+  , "category": "Objects"
+  , "aliases": [
+      "guitar"
+    ]
+  , "tags": [
+      "rock"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎹"
+  , "description": "musical keyboard"
+  , "category": "Objects"
+  , "aliases": [
+      "musical_keyboard"
+    ]
+  , "tags": [
+      "piano"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎺"
+  , "description": "trumpet"
+  , "category": "Objects"
+  , "aliases": [
+      "trumpet"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎻"
+  , "description": "violin"
+  , "category": "Objects"
+  , "aliases": [
+      "violin"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪕"
+  , "description": "banjo"
+  , "category": "Objects"
+  , "aliases": [
+      "banjo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🥁"
+  , "description": "drum"
+  , "category": "Objects"
+  , "aliases": [
+      "drum"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🪘"
+  , "description": "long drum"
+  , "category": "Objects"
+  , "aliases": [
+      "long_drum"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "📱"
+  , "description": "mobile phone"
+  , "category": "Objects"
+  , "aliases": [
+      "iphone"
+    ]
+  , "tags": [
+      "smartphone"
+    , "mobile"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📲"
+  , "description": "mobile phone with arrow"
+  , "category": "Objects"
+  , "aliases": [
+      "calling"
+    ]
+  , "tags": [
+      "call"
+    , "incoming"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "☎️"
+  , "description": "telephone"
+  , "category": "Objects"
+  , "aliases": [
+      "phone"
+    , "telephone"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📞"
+  , "description": "telephone receiver"
+  , "category": "Objects"
+  , "aliases": [
+      "telephone_receiver"
+    ]
+  , "tags": [
+      "phone"
+    , "call"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📟"
+  , "description": "pager"
+  , "category": "Objects"
+  , "aliases": [
+      "pager"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📠"
+  , "description": "fax machine"
+  , "category": "Objects"
+  , "aliases": [
+      "fax"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔋"
+  , "description": "battery"
+  , "category": "Objects"
+  , "aliases": [
+      "battery"
+    ]
+  , "tags": [
+      "power"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔌"
+  , "description": "electric plug"
+  , "category": "Objects"
+  , "aliases": [
+      "electric_plug"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💻"
+  , "description": "laptop"
+  , "category": "Objects"
+  , "aliases": [
+      "computer"
+    ]
+  , "tags": [
+      "desktop"
+    , "screen"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🖥️"
+  , "description": "desktop computer"
+  , "category": "Objects"
+  , "aliases": [
+      "desktop_computer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🖨️"
+  , "description": "printer"
+  , "category": "Objects"
+  , "aliases": [
+      "printer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⌨️"
+  , "description": "keyboard"
+  , "category": "Objects"
+  , "aliases": [
+      "keyboard"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🖱️"
+  , "description": "computer mouse"
+  , "category": "Objects"
+  , "aliases": [
+      "computer_mouse"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🖲️"
+  , "description": "trackball"
+  , "category": "Objects"
+  , "aliases": [
+      "trackball"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "💽"
+  , "description": "computer disk"
+  , "category": "Objects"
+  , "aliases": [
+      "minidisc"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💾"
+  , "description": "floppy disk"
+  , "category": "Objects"
+  , "aliases": [
+      "floppy_disk"
+    ]
+  , "tags": [
+      "save"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💿"
+  , "description": "optical disk"
+  , "category": "Objects"
+  , "aliases": [
+      "cd"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📀"
+  , "description": "dvd"
+  , "category": "Objects"
+  , "aliases": [
+      "dvd"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧮"
+  , "description": "abacus"
+  , "category": "Objects"
+  , "aliases": [
+      "abacus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🎥"
+  , "description": "movie camera"
+  , "category": "Objects"
+  , "aliases": [
+      "movie_camera"
+    ]
+  , "tags": [
+      "film"
+    , "video"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎞️"
+  , "description": "film frames"
+  , "category": "Objects"
+  , "aliases": [
+      "film_strip"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "📽️"
+  , "description": "film projector"
+  , "category": "Objects"
+  , "aliases": [
+      "film_projector"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🎬"
+  , "description": "clapper board"
+  , "category": "Objects"
+  , "aliases": [
+      "clapper"
+    ]
+  , "tags": [
+      "film"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📺"
+  , "description": "television"
+  , "category": "Objects"
+  , "aliases": [
+      "tv"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📷"
+  , "description": "camera"
+  , "category": "Objects"
+  , "aliases": [
+      "camera"
+    ]
+  , "tags": [
+      "photo"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📸"
+  , "description": "camera with flash"
+  , "category": "Objects"
+  , "aliases": [
+      "camera_flash"
+    ]
+  , "tags": [
+      "photo"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "📹"
+  , "description": "video camera"
+  , "category": "Objects"
+  , "aliases": [
+      "video_camera"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📼"
+  , "description": "videocassette"
+  , "category": "Objects"
+  , "aliases": [
+      "vhs"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔍"
+  , "description": "magnifying glass tilted left"
+  , "category": "Objects"
+  , "aliases": [
+      "mag"
+    ]
+  , "tags": [
+      "search"
+    , "zoom"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔎"
+  , "description": "magnifying glass tilted right"
+  , "category": "Objects"
+  , "aliases": [
+      "mag_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🕯️"
+  , "description": "candle"
+  , "category": "Objects"
+  , "aliases": [
+      "candle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "💡"
+  , "description": "light bulb"
+  , "category": "Objects"
+  , "aliases": [
+      "bulb"
+    ]
+  , "tags": [
+      "idea"
+    , "light"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔦"
+  , "description": "flashlight"
+  , "category": "Objects"
+  , "aliases": [
+      "flashlight"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏮"
+  , "description": "red paper lantern"
+  , "category": "Objects"
+  , "aliases": [
+      "izakaya_lantern"
+    , "lantern"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪔"
+  , "description": "diya lamp"
+  , "category": "Objects"
+  , "aliases": [
+      "diya_lamp"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "📔"
+  , "description": "notebook with decorative cover"
+  , "category": "Objects"
+  , "aliases": [
+      "notebook_with_decorative_cover"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📕"
+  , "description": "closed book"
+  , "category": "Objects"
+  , "aliases": [
+      "closed_book"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📖"
+  , "description": "open book"
+  , "category": "Objects"
+  , "aliases": [
+      "book"
+    , "open_book"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📗"
+  , "description": "green book"
+  , "category": "Objects"
+  , "aliases": [
+      "green_book"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📘"
+  , "description": "blue book"
+  , "category": "Objects"
+  , "aliases": [
+      "blue_book"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📙"
+  , "description": "orange book"
+  , "category": "Objects"
+  , "aliases": [
+      "orange_book"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📚"
+  , "description": "books"
+  , "category": "Objects"
+  , "aliases": [
+      "books"
+    ]
+  , "tags": [
+      "library"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📓"
+  , "description": "notebook"
+  , "category": "Objects"
+  , "aliases": [
+      "notebook"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📒"
+  , "description": "ledger"
+  , "category": "Objects"
+  , "aliases": [
+      "ledger"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📃"
+  , "description": "page with curl"
+  , "category": "Objects"
+  , "aliases": [
+      "page_with_curl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📜"
+  , "description": "scroll"
+  , "category": "Objects"
+  , "aliases": [
+      "scroll"
+    ]
+  , "tags": [
+      "document"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📄"
+  , "description": "page facing up"
+  , "category": "Objects"
+  , "aliases": [
+      "page_facing_up"
+    ]
+  , "tags": [
+      "document"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📰"
+  , "description": "newspaper"
+  , "category": "Objects"
+  , "aliases": [
+      "newspaper"
+    ]
+  , "tags": [
+      "press"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🗞️"
+  , "description": "rolled-up newspaper"
+  , "category": "Objects"
+  , "aliases": [
+      "newspaper_roll"
+    ]
+  , "tags": [
+      "press"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "📑"
+  , "description": "bookmark tabs"
+  , "category": "Objects"
+  , "aliases": [
+      "bookmark_tabs"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔖"
+  , "description": "bookmark"
+  , "category": "Objects"
+  , "aliases": [
+      "bookmark"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏷️"
+  , "description": "label"
+  , "category": "Objects"
+  , "aliases": [
+      "label"
+    ]
+  , "tags": [
+      "tag"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "💰"
+  , "description": "money bag"
+  , "category": "Objects"
+  , "aliases": [
+      "moneybag"
+    ]
+  , "tags": [
+      "dollar"
+    , "cream"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪙"
+  , "description": "coin"
+  , "category": "Objects"
+  , "aliases": [
+      "coin"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "💴"
+  , "description": "yen banknote"
+  , "category": "Objects"
+  , "aliases": [
+      "yen"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💵"
+  , "description": "dollar banknote"
+  , "category": "Objects"
+  , "aliases": [
+      "dollar"
+    ]
+  , "tags": [
+      "money"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💶"
+  , "description": "euro banknote"
+  , "category": "Objects"
+  , "aliases": [
+      "euro"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💷"
+  , "description": "pound banknote"
+  , "category": "Objects"
+  , "aliases": [
+      "pound"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💸"
+  , "description": "money with wings"
+  , "category": "Objects"
+  , "aliases": [
+      "money_with_wings"
+    ]
+  , "tags": [
+      "dollar"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💳"
+  , "description": "credit card"
+  , "category": "Objects"
+  , "aliases": [
+      "credit_card"
+    ]
+  , "tags": [
+      "subscription"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧾"
+  , "description": "receipt"
+  , "category": "Objects"
+  , "aliases": [
+      "receipt"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "💹"
+  , "description": "chart increasing with yen"
+  , "category": "Objects"
+  , "aliases": [
+      "chart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "✉️"
+  , "description": "envelope"
+  , "category": "Objects"
+  , "aliases": [
+      "envelope"
+    ]
+  , "tags": [
+      "letter"
+    , "email"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📧"
+  , "description": "e-mail"
+  , "category": "Objects"
+  , "aliases": [
+      "email"
+    , "e-mail"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📨"
+  , "description": "incoming envelope"
+  , "category": "Objects"
+  , "aliases": [
+      "incoming_envelope"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📩"
+  , "description": "envelope with arrow"
+  , "category": "Objects"
+  , "aliases": [
+      "envelope_with_arrow"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📤"
+  , "description": "outbox tray"
+  , "category": "Objects"
+  , "aliases": [
+      "outbox_tray"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📥"
+  , "description": "inbox tray"
+  , "category": "Objects"
+  , "aliases": [
+      "inbox_tray"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📦"
+  , "description": "package"
+  , "category": "Objects"
+  , "aliases": [
+      "package"
+    ]
+  , "tags": [
+      "shipping"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📫"
+  , "description": "closed mailbox with raised flag"
+  , "category": "Objects"
+  , "aliases": [
+      "mailbox"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📪"
+  , "description": "closed mailbox with lowered flag"
+  , "category": "Objects"
+  , "aliases": [
+      "mailbox_closed"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📬"
+  , "description": "open mailbox with raised flag"
+  , "category": "Objects"
+  , "aliases": [
+      "mailbox_with_mail"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📭"
+  , "description": "open mailbox with lowered flag"
+  , "category": "Objects"
+  , "aliases": [
+      "mailbox_with_no_mail"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📮"
+  , "description": "postbox"
+  , "category": "Objects"
+  , "aliases": [
+      "postbox"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🗳️"
+  , "description": "ballot box with ballot"
+  , "category": "Objects"
+  , "aliases": [
+      "ballot_box"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "✏️"
+  , "description": "pencil"
+  , "category": "Objects"
+  , "aliases": [
+      "pencil2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "✒️"
+  , "description": "black nib"
+  , "category": "Objects"
+  , "aliases": [
+      "black_nib"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🖋️"
+  , "description": "fountain pen"
+  , "category": "Objects"
+  , "aliases": [
+      "fountain_pen"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🖊️"
+  , "description": "pen"
+  , "category": "Objects"
+  , "aliases": [
+      "pen"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🖌️"
+  , "description": "paintbrush"
+  , "category": "Objects"
+  , "aliases": [
+      "paintbrush"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🖍️"
+  , "description": "crayon"
+  , "category": "Objects"
+  , "aliases": [
+      "crayon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "📝"
+  , "description": "memo"
+  , "category": "Objects"
+  , "aliases": [
+      "memo"
+    , "pencil"
+    ]
+  , "tags": [
+      "document"
+    , "note"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💼"
+  , "description": "briefcase"
+  , "category": "Objects"
+  , "aliases": [
+      "briefcase"
+    ]
+  , "tags": [
+      "business"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📁"
+  , "description": "file folder"
+  , "category": "Objects"
+  , "aliases": [
+      "file_folder"
+    ]
+  , "tags": [
+      "directory"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📂"
+  , "description": "open file folder"
+  , "category": "Objects"
+  , "aliases": [
+      "open_file_folder"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🗂️"
+  , "description": "card index dividers"
+  , "category": "Objects"
+  , "aliases": [
+      "card_index_dividers"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "📅"
+  , "description": "calendar"
+  , "category": "Objects"
+  , "aliases": [
+      "date"
+    ]
+  , "tags": [
+      "calendar"
+    , "schedule"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📆"
+  , "description": "tear-off calendar"
+  , "category": "Objects"
+  , "aliases": [
+      "calendar"
+    ]
+  , "tags": [
+      "schedule"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🗒️"
+  , "description": "spiral notepad"
+  , "category": "Objects"
+  , "aliases": [
+      "spiral_notepad"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🗓️"
+  , "description": "spiral calendar"
+  , "category": "Objects"
+  , "aliases": [
+      "spiral_calendar"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "📇"
+  , "description": "card index"
+  , "category": "Objects"
+  , "aliases": [
+      "card_index"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📈"
+  , "description": "chart increasing"
+  , "category": "Objects"
+  , "aliases": [
+      "chart_with_upwards_trend"
+    ]
+  , "tags": [
+      "graph"
+    , "metrics"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📉"
+  , "description": "chart decreasing"
+  , "category": "Objects"
+  , "aliases": [
+      "chart_with_downwards_trend"
+    ]
+  , "tags": [
+      "graph"
+    , "metrics"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📊"
+  , "description": "bar chart"
+  , "category": "Objects"
+  , "aliases": [
+      "bar_chart"
+    ]
+  , "tags": [
+      "stats"
+    , "metrics"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📋"
+  , "description": "clipboard"
+  , "category": "Objects"
+  , "aliases": [
+      "clipboard"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📌"
+  , "description": "pushpin"
+  , "category": "Objects"
+  , "aliases": [
+      "pushpin"
+    ]
+  , "tags": [
+      "location"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📍"
+  , "description": "round pushpin"
+  , "category": "Objects"
+  , "aliases": [
+      "round_pushpin"
+    ]
+  , "tags": [
+      "location"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📎"
+  , "description": "paperclip"
+  , "category": "Objects"
+  , "aliases": [
+      "paperclip"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🖇️"
+  , "description": "linked paperclips"
+  , "category": "Objects"
+  , "aliases": [
+      "paperclips"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "📏"
+  , "description": "straight ruler"
+  , "category": "Objects"
+  , "aliases": [
+      "straight_ruler"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📐"
+  , "description": "triangular ruler"
+  , "category": "Objects"
+  , "aliases": [
+      "triangular_ruler"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "✂️"
+  , "description": "scissors"
+  , "category": "Objects"
+  , "aliases": [
+      "scissors"
+    ]
+  , "tags": [
+      "cut"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🗃️"
+  , "description": "card file box"
+  , "category": "Objects"
+  , "aliases": [
+      "card_file_box"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🗄️"
+  , "description": "file cabinet"
+  , "category": "Objects"
+  , "aliases": [
+      "file_cabinet"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🗑️"
+  , "description": "wastebasket"
+  , "category": "Objects"
+  , "aliases": [
+      "wastebasket"
+    ]
+  , "tags": [
+      "trash"
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🔒"
+  , "description": "locked"
+  , "category": "Objects"
+  , "aliases": [
+      "lock"
+    ]
+  , "tags": [
+      "security"
+    , "private"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔓"
+  , "description": "unlocked"
+  , "category": "Objects"
+  , "aliases": [
+      "unlock"
+    ]
+  , "tags": [
+      "security"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔏"
+  , "description": "locked with pen"
+  , "category": "Objects"
+  , "aliases": [
+      "lock_with_ink_pen"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔐"
+  , "description": "locked with key"
+  , "category": "Objects"
+  , "aliases": [
+      "closed_lock_with_key"
+    ]
+  , "tags": [
+      "security"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔑"
+  , "description": "key"
+  , "category": "Objects"
+  , "aliases": [
+      "key"
+    ]
+  , "tags": [
+      "lock"
+    , "password"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🗝️"
+  , "description": "old key"
+  , "category": "Objects"
+  , "aliases": [
+      "old_key"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🔨"
+  , "description": "hammer"
+  , "category": "Objects"
+  , "aliases": [
+      "hammer"
+    ]
+  , "tags": [
+      "tool"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪓"
+  , "description": "axe"
+  , "category": "Objects"
+  , "aliases": [
+      "axe"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "⛏️"
+  , "description": "pick"
+  , "category": "Objects"
+  , "aliases": [
+      "pick"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⚒️"
+  , "description": "hammer and pick"
+  , "category": "Objects"
+  , "aliases": [
+      "hammer_and_pick"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛠️"
+  , "description": "hammer and wrench"
+  , "category": "Objects"
+  , "aliases": [
+      "hammer_and_wrench"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🗡️"
+  , "description": "dagger"
+  , "category": "Objects"
+  , "aliases": [
+      "dagger"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⚔️"
+  , "description": "crossed swords"
+  , "category": "Objects"
+  , "aliases": [
+      "crossed_swords"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🔫"
+  , "description": "pistol"
+  , "category": "Objects"
+  , "aliases": [
+      "gun"
+    ]
+  , "tags": [
+      "shoot"
+    , "weapon"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪃"
+  , "description": "boomerang"
+  , "category": "Objects"
+  , "aliases": [
+      "boomerang"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🏹"
+  , "description": "bow and arrow"
+  , "category": "Objects"
+  , "aliases": [
+      "bow_and_arrow"
+    ]
+  , "tags": [
+      "archery"
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛡️"
+  , "description": "shield"
+  , "category": "Objects"
+  , "aliases": [
+      "shield"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🪚"
+  , "description": "carpentry saw"
+  , "category": "Objects"
+  , "aliases": [
+      "carpentry_saw"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🔧"
+  , "description": "wrench"
+  , "category": "Objects"
+  , "aliases": [
+      "wrench"
+    ]
+  , "tags": [
+      "tool"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪛"
+  , "description": "screwdriver"
+  , "category": "Objects"
+  , "aliases": [
+      "screwdriver"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🔩"
+  , "description": "nut and bolt"
+  , "category": "Objects"
+  , "aliases": [
+      "nut_and_bolt"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⚙️"
+  , "description": "gear"
+  , "category": "Objects"
+  , "aliases": [
+      "gear"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🗜️"
+  , "description": "clamp"
+  , "category": "Objects"
+  , "aliases": [
+      "clamp"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⚖️"
+  , "description": "balance scale"
+  , "category": "Objects"
+  , "aliases": [
+      "balance_scale"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🦯"
+  , "description": "white cane"
+  , "category": "Objects"
+  , "aliases": [
+      "probing_cane"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🔗"
+  , "description": "link"
+  , "category": "Objects"
+  , "aliases": [
+      "link"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⛓️"
+  , "description": "chains"
+  , "category": "Objects"
+  , "aliases": [
+      "chains"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🪝"
+  , "description": "hook"
+  , "category": "Objects"
+  , "aliases": [
+      "hook"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🧰"
+  , "description": "toolbox"
+  , "category": "Objects"
+  , "aliases": [
+      "toolbox"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧲"
+  , "description": "magnet"
+  , "category": "Objects"
+  , "aliases": [
+      "magnet"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🪜"
+  , "description": "ladder"
+  , "category": "Objects"
+  , "aliases": [
+      "ladder"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "⚗️"
+  , "description": "alembic"
+  , "category": "Objects"
+  , "aliases": [
+      "alembic"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🧪"
+  , "description": "test tube"
+  , "category": "Objects"
+  , "aliases": [
+      "test_tube"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧫"
+  , "description": "petri dish"
+  , "category": "Objects"
+  , "aliases": [
+      "petri_dish"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧬"
+  , "description": "dna"
+  , "category": "Objects"
+  , "aliases": [
+      "dna"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🔬"
+  , "description": "microscope"
+  , "category": "Objects"
+  , "aliases": [
+      "microscope"
+    ]
+  , "tags": [
+      "science"
+    , "laboratory"
+    , "investigate"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔭"
+  , "description": "telescope"
+  , "category": "Objects"
+  , "aliases": [
+      "telescope"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📡"
+  , "description": "satellite antenna"
+  , "category": "Objects"
+  , "aliases": [
+      "satellite"
+    ]
+  , "tags": [
+      "signal"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💉"
+  , "description": "syringe"
+  , "category": "Objects"
+  , "aliases": [
+      "syringe"
+    ]
+  , "tags": [
+      "health"
+    , "hospital"
+    , "needle"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🩸"
+  , "description": "drop of blood"
+  , "category": "Objects"
+  , "aliases": [
+      "drop_of_blood"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "💊"
+  , "description": "pill"
+  , "category": "Objects"
+  , "aliases": [
+      "pill"
+    ]
+  , "tags": [
+      "health"
+    , "medicine"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🩹"
+  , "description": "adhesive bandage"
+  , "category": "Objects"
+  , "aliases": [
+      "adhesive_bandage"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🩺"
+  , "description": "stethoscope"
+  , "category": "Objects"
+  , "aliases": [
+      "stethoscope"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🚪"
+  , "description": "door"
+  , "category": "Objects"
+  , "aliases": [
+      "door"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛗"
+  , "description": "elevator"
+  , "category": "Objects"
+  , "aliases": [
+      "elevator"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🪞"
+  , "description": "mirror"
+  , "category": "Objects"
+  , "aliases": [
+      "mirror"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🪟"
+  , "description": "window"
+  , "category": "Objects"
+  , "aliases": [
+      "window"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🛏️"
+  , "description": "bed"
+  , "category": "Objects"
+  , "aliases": [
+      "bed"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛋️"
+  , "description": "couch and lamp"
+  , "category": "Objects"
+  , "aliases": [
+      "couch_and_lamp"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🪑"
+  , "description": "chair"
+  , "category": "Objects"
+  , "aliases": [
+      "chair"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🚽"
+  , "description": "toilet"
+  , "category": "Objects"
+  , "aliases": [
+      "toilet"
+    ]
+  , "tags": [
+      "wc"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪠"
+  , "description": "plunger"
+  , "category": "Objects"
+  , "aliases": [
+      "plunger"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🚿"
+  , "description": "shower"
+  , "category": "Objects"
+  , "aliases": [
+      "shower"
+    ]
+  , "tags": [
+      "bath"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛁"
+  , "description": "bathtub"
+  , "category": "Objects"
+  , "aliases": [
+      "bathtub"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪤"
+  , "description": "mouse trap"
+  , "category": "Objects"
+  , "aliases": [
+      "mouse_trap"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🪒"
+  , "description": "razor"
+  , "category": "Objects"
+  , "aliases": [
+      "razor"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🧴"
+  , "description": "lotion bottle"
+  , "category": "Objects"
+  , "aliases": [
+      "lotion_bottle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧷"
+  , "description": "safety pin"
+  , "category": "Objects"
+  , "aliases": [
+      "safety_pin"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧹"
+  , "description": "broom"
+  , "category": "Objects"
+  , "aliases": [
+      "broom"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧺"
+  , "description": "basket"
+  , "category": "Objects"
+  , "aliases": [
+      "basket"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧻"
+  , "description": "roll of paper"
+  , "category": "Objects"
+  , "aliases": [
+      "roll_of_paper"
+    ]
+  , "tags": [
+      "toilet"
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🪣"
+  , "description": "bucket"
+  , "category": "Objects"
+  , "aliases": [
+      "bucket"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🧼"
+  , "description": "soap"
+  , "category": "Objects"
+  , "aliases": [
+      "soap"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🪥"
+  , "description": "toothbrush"
+  , "category": "Objects"
+  , "aliases": [
+      "toothbrush"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🧽"
+  , "description": "sponge"
+  , "category": "Objects"
+  , "aliases": [
+      "sponge"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🧯"
+  , "description": "fire extinguisher"
+  , "category": "Objects"
+  , "aliases": [
+      "fire_extinguisher"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🛒"
+  , "description": "shopping cart"
+  , "category": "Objects"
+  , "aliases": [
+      "shopping_cart"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🚬"
+  , "description": "cigarette"
+  , "category": "Objects"
+  , "aliases": [
+      "smoking"
+    ]
+  , "tags": [
+      "cigarette"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⚰️"
+  , "description": "coffin"
+  , "category": "Objects"
+  , "aliases": [
+      "coffin"
+    ]
+  , "tags": [
+      "funeral"
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🪦"
+  , "description": "headstone"
+  , "category": "Objects"
+  , "aliases": [
+      "headstone"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "⚱️"
+  , "description": "funeral urn"
+  , "category": "Objects"
+  , "aliases": [
+      "funeral_urn"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🗿"
+  , "description": "moai"
+  , "category": "Objects"
+  , "aliases": [
+      "moyai"
+    ]
+  , "tags": [
+      "stone"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪧"
+  , "description": "placard"
+  , "category": "Objects"
+  , "aliases": [
+      "placard"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🏧"
+  , "description": "ATM sign"
+  , "category": "Symbols"
+  , "aliases": [
+      "atm"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚮"
+  , "description": "litter in bin sign"
+  , "category": "Symbols"
+  , "aliases": [
+      "put_litter_in_its_place"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚰"
+  , "description": "potable water"
+  , "category": "Symbols"
+  , "aliases": [
+      "potable_water"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♿"
+  , "description": "wheelchair symbol"
+  , "category": "Symbols"
+  , "aliases": [
+      "wheelchair"
+    ]
+  , "tags": [
+      "accessibility"
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚹"
+  , "description": "men’s room"
+  , "category": "Symbols"
+  , "aliases": [
+      "mens"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚺"
+  , "description": "women’s room"
+  , "category": "Symbols"
+  , "aliases": [
+      "womens"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚻"
+  , "description": "restroom"
+  , "category": "Symbols"
+  , "aliases": [
+      "restroom"
+    ]
+  , "tags": [
+      "toilet"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚼"
+  , "description": "baby symbol"
+  , "category": "Symbols"
+  , "aliases": [
+      "baby_symbol"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚾"
+  , "description": "water closet"
+  , "category": "Symbols"
+  , "aliases": [
+      "wc"
+    ]
+  , "tags": [
+      "toilet"
+    , "restroom"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛂"
+  , "description": "passport control"
+  , "category": "Symbols"
+  , "aliases": [
+      "passport_control"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛃"
+  , "description": "customs"
+  , "category": "Symbols"
+  , "aliases": [
+      "customs"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛄"
+  , "description": "baggage claim"
+  , "category": "Symbols"
+  , "aliases": [
+      "baggage_claim"
+    ]
+  , "tags": [
+      "airport"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛅"
+  , "description": "left luggage"
+  , "category": "Symbols"
+  , "aliases": [
+      "left_luggage"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⚠️"
+  , "description": "warning"
+  , "category": "Symbols"
+  , "aliases": [
+      "warning"
+    ]
+  , "tags": [
+      "wip"
+    ]
+  , "unicode_version": "4.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚸"
+  , "description": "children crossing"
+  , "category": "Symbols"
+  , "aliases": [
+      "children_crossing"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⛔"
+  , "description": "no entry"
+  , "category": "Symbols"
+  , "aliases": [
+      "no_entry"
+    ]
+  , "tags": [
+      "limit"
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚫"
+  , "description": "prohibited"
+  , "category": "Symbols"
+  , "aliases": [
+      "no_entry_sign"
+    ]
+  , "tags": [
+      "block"
+    , "forbidden"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚳"
+  , "description": "no bicycles"
+  , "category": "Symbols"
+  , "aliases": [
+      "no_bicycles"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚭"
+  , "description": "no smoking"
+  , "category": "Symbols"
+  , "aliases": [
+      "no_smoking"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚯"
+  , "description": "no littering"
+  , "category": "Symbols"
+  , "aliases": [
+      "do_not_litter"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚱"
+  , "description": "non-potable water"
+  , "category": "Symbols"
+  , "aliases": [
+      "non-potable_water"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚷"
+  , "description": "no pedestrians"
+  , "category": "Symbols"
+  , "aliases": [
+      "no_pedestrians"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📵"
+  , "description": "no mobile phones"
+  , "category": "Symbols"
+  , "aliases": [
+      "no_mobile_phones"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔞"
+  , "description": "no one under eighteen"
+  , "category": "Symbols"
+  , "aliases": [
+      "underage"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "☢️"
+  , "description": "radioactive"
+  , "category": "Symbols"
+  , "aliases": [
+      "radioactive"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "☣️"
+  , "description": "biohazard"
+  , "category": "Symbols"
+  , "aliases": [
+      "biohazard"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⬆️"
+  , "description": "up arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_up"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "↗️"
+  , "description": "up-right arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_upper_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "➡️"
+  , "description": "right arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "↘️"
+  , "description": "down-right arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_lower_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⬇️"
+  , "description": "down arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_down"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "↙️"
+  , "description": "down-left arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_lower_left"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⬅️"
+  , "description": "left arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_left"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "↖️"
+  , "description": "up-left arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_upper_left"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "↕️"
+  , "description": "up-down arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_up_down"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "↔️"
+  , "description": "left-right arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "left_right_arrow"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "↩️"
+  , "description": "right arrow curving left"
+  , "category": "Symbols"
+  , "aliases": [
+      "leftwards_arrow_with_hook"
+    ]
+  , "tags": [
+      "return"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "↪️"
+  , "description": "left arrow curving right"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_right_hook"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⤴️"
+  , "description": "right arrow curving up"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_heading_up"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⤵️"
+  , "description": "right arrow curving down"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_heading_down"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔃"
+  , "description": "clockwise vertical arrows"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrows_clockwise"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔄"
+  , "description": "counterclockwise arrows button"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrows_counterclockwise"
+    ]
+  , "tags": [
+      "sync"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔙"
+  , "description": "BACK arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "back"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔚"
+  , "description": "END arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "end"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔛"
+  , "description": "ON! arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "on"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔜"
+  , "description": "SOON arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "soon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔝"
+  , "description": "TOP arrow"
+  , "category": "Symbols"
+  , "aliases": [
+      "top"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🛐"
+  , "description": "place of worship"
+  , "category": "Symbols"
+  , "aliases": [
+      "place_of_worship"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⚛️"
+  , "description": "atom symbol"
+  , "category": "Symbols"
+  , "aliases": [
+      "atom_symbol"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🕉️"
+  , "description": "om"
+  , "category": "Symbols"
+  , "aliases": [
+      "om"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "✡️"
+  , "description": "star of David"
+  , "category": "Symbols"
+  , "aliases": [
+      "star_of_david"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "☸️"
+  , "description": "wheel of dharma"
+  , "category": "Symbols"
+  , "aliases": [
+      "wheel_of_dharma"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "☯️"
+  , "description": "yin yang"
+  , "category": "Symbols"
+  , "aliases": [
+      "yin_yang"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "✝️"
+  , "description": "latin cross"
+  , "category": "Symbols"
+  , "aliases": [
+      "latin_cross"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "☦️"
+  , "description": "orthodox cross"
+  , "category": "Symbols"
+  , "aliases": [
+      "orthodox_cross"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "☪️"
+  , "description": "star and crescent"
+  , "category": "Symbols"
+  , "aliases": [
+      "star_and_crescent"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "☮️"
+  , "description": "peace symbol"
+  , "category": "Symbols"
+  , "aliases": [
+      "peace_symbol"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🕎"
+  , "description": "menorah"
+  , "category": "Symbols"
+  , "aliases": [
+      "menorah"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🔯"
+  , "description": "dotted six-pointed star"
+  , "category": "Symbols"
+  , "aliases": [
+      "six_pointed_star"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♈"
+  , "description": "Aries"
+  , "category": "Symbols"
+  , "aliases": [
+      "aries"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♉"
+  , "description": "Taurus"
+  , "category": "Symbols"
+  , "aliases": [
+      "taurus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♊"
+  , "description": "Gemini"
+  , "category": "Symbols"
+  , "aliases": [
+      "gemini"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♋"
+  , "description": "Cancer"
+  , "category": "Symbols"
+  , "aliases": [
+      "cancer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♌"
+  , "description": "Leo"
+  , "category": "Symbols"
+  , "aliases": [
+      "leo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♍"
+  , "description": "Virgo"
+  , "category": "Symbols"
+  , "aliases": [
+      "virgo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♎"
+  , "description": "Libra"
+  , "category": "Symbols"
+  , "aliases": [
+      "libra"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♏"
+  , "description": "Scorpio"
+  , "category": "Symbols"
+  , "aliases": [
+      "scorpius"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♐"
+  , "description": "Sagittarius"
+  , "category": "Symbols"
+  , "aliases": [
+      "sagittarius"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♑"
+  , "description": "Capricorn"
+  , "category": "Symbols"
+  , "aliases": [
+      "capricorn"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♒"
+  , "description": "Aquarius"
+  , "category": "Symbols"
+  , "aliases": [
+      "aquarius"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♓"
+  , "description": "Pisces"
+  , "category": "Symbols"
+  , "aliases": [
+      "pisces"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⛎"
+  , "description": "Ophiuchus"
+  , "category": "Symbols"
+  , "aliases": [
+      "ophiuchus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔀"
+  , "description": "shuffle tracks button"
+  , "category": "Symbols"
+  , "aliases": [
+      "twisted_rightwards_arrows"
+    ]
+  , "tags": [
+      "shuffle"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔁"
+  , "description": "repeat button"
+  , "category": "Symbols"
+  , "aliases": [
+      "repeat"
+    ]
+  , "tags": [
+      "loop"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔂"
+  , "description": "repeat single button"
+  , "category": "Symbols"
+  , "aliases": [
+      "repeat_one"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "▶️"
+  , "description": "play button"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_forward"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⏩"
+  , "description": "fast-forward button"
+  , "category": "Symbols"
+  , "aliases": [
+      "fast_forward"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⏭️"
+  , "description": "next track button"
+  , "category": "Symbols"
+  , "aliases": [
+      "next_track_button"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⏯️"
+  , "description": "play or pause button"
+  , "category": "Symbols"
+  , "aliases": [
+      "play_or_pause_button"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "◀️"
+  , "description": "reverse button"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_backward"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⏪"
+  , "description": "fast reverse button"
+  , "category": "Symbols"
+  , "aliases": [
+      "rewind"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⏮️"
+  , "description": "last track button"
+  , "category": "Symbols"
+  , "aliases": [
+      "previous_track_button"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🔼"
+  , "description": "upwards button"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_up_small"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⏫"
+  , "description": "fast up button"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_double_up"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔽"
+  , "description": "downwards button"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_down_small"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⏬"
+  , "description": "fast down button"
+  , "category": "Symbols"
+  , "aliases": [
+      "arrow_double_down"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⏸️"
+  , "description": "pause button"
+  , "category": "Symbols"
+  , "aliases": [
+      "pause_button"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⏹️"
+  , "description": "stop button"
+  , "category": "Symbols"
+  , "aliases": [
+      "stop_button"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⏺️"
+  , "description": "record button"
+  , "category": "Symbols"
+  , "aliases": [
+      "record_button"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "⏏️"
+  , "description": "eject button"
+  , "category": "Symbols"
+  , "aliases": [
+      "eject_button"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🎦"
+  , "description": "cinema"
+  , "category": "Symbols"
+  , "aliases": [
+      "cinema"
+    ]
+  , "tags": [
+      "film"
+    , "movie"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔅"
+  , "description": "dim button"
+  , "category": "Symbols"
+  , "aliases": [
+      "low_brightness"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔆"
+  , "description": "bright button"
+  , "category": "Symbols"
+  , "aliases": [
+      "high_brightness"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📶"
+  , "description": "antenna bars"
+  , "category": "Symbols"
+  , "aliases": [
+      "signal_strength"
+    ]
+  , "tags": [
+      "wifi"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📳"
+  , "description": "vibration mode"
+  , "category": "Symbols"
+  , "aliases": [
+      "vibration_mode"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📴"
+  , "description": "mobile phone off"
+  , "category": "Symbols"
+  , "aliases": [
+      "mobile_phone_off"
+    ]
+  , "tags": [
+      "mute"
+    , "off"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♀️"
+  , "description": "female sign"
+  , "category": "Symbols"
+  , "aliases": [
+      "female_sign"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "♂️"
+  , "description": "male sign"
+  , "category": "Symbols"
+  , "aliases": [
+      "male_sign"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "⚧️"
+  , "description": "transgender symbol"
+  , "category": "Symbols"
+  , "aliases": [
+      "transgender_symbol"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "✖️"
+  , "description": "multiply"
+  , "category": "Symbols"
+  , "aliases": [
+      "heavy_multiplication_x"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "➕"
+  , "description": "plus"
+  , "category": "Symbols"
+  , "aliases": [
+      "heavy_plus_sign"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "➖"
+  , "description": "minus"
+  , "category": "Symbols"
+  , "aliases": [
+      "heavy_minus_sign"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "➗"
+  , "description": "divide"
+  , "category": "Symbols"
+  , "aliases": [
+      "heavy_division_sign"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "♾️"
+  , "description": "infinity"
+  , "category": "Symbols"
+  , "aliases": [
+      "infinity"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "‼️"
+  , "description": "double exclamation mark"
+  , "category": "Symbols"
+  , "aliases": [
+      "bangbang"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⁉️"
+  , "description": "exclamation question mark"
+  , "category": "Symbols"
+  , "aliases": [
+      "interrobang"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "3.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "❓"
+  , "description": "question mark"
+  , "category": "Symbols"
+  , "aliases": [
+      "question"
+    ]
+  , "tags": [
+      "confused"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "❔"
+  , "description": "white question mark"
+  , "category": "Symbols"
+  , "aliases": [
+      "grey_question"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "❕"
+  , "description": "white exclamation mark"
+  , "category": "Symbols"
+  , "aliases": [
+      "grey_exclamation"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "❗"
+  , "description": "exclamation mark"
+  , "category": "Symbols"
+  , "aliases": [
+      "exclamation"
+    , "heavy_exclamation_mark"
+    ]
+  , "tags": [
+      "bang"
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "〰️"
+  , "description": "wavy dash"
+  , "category": "Symbols"
+  , "aliases": [
+      "wavy_dash"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💱"
+  , "description": "currency exchange"
+  , "category": "Symbols"
+  , "aliases": [
+      "currency_exchange"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💲"
+  , "description": "heavy dollar sign"
+  , "category": "Symbols"
+  , "aliases": [
+      "heavy_dollar_sign"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⚕️"
+  , "description": "medical symbol"
+  , "category": "Symbols"
+  , "aliases": [
+      "medical_symbol"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "♻️"
+  , "description": "recycling symbol"
+  , "category": "Symbols"
+  , "aliases": [
+      "recycle"
+    ]
+  , "tags": [
+      "environment"
+    , "green"
+    ]
+  , "unicode_version": "3.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⚜️"
+  , "description": "fleur-de-lis"
+  , "category": "Symbols"
+  , "aliases": [
+      "fleur_de_lis"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🔱"
+  , "description": "trident emblem"
+  , "category": "Symbols"
+  , "aliases": [
+      "trident"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "📛"
+  , "description": "name badge"
+  , "category": "Symbols"
+  , "aliases": [
+      "name_badge"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔰"
+  , "description": "Japanese symbol for beginner"
+  , "category": "Symbols"
+  , "aliases": [
+      "beginner"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⭕"
+  , "description": "hollow red circle"
+  , "category": "Symbols"
+  , "aliases": [
+      "o"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "✅"
+  , "description": "check mark button"
+  , "category": "Symbols"
+  , "aliases": [
+      "white_check_mark"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "☑️"
+  , "description": "check box with check"
+  , "category": "Symbols"
+  , "aliases": [
+      "ballot_box_with_check"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "✔️"
+  , "description": "check mark"
+  , "category": "Symbols"
+  , "aliases": [
+      "heavy_check_mark"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "❌"
+  , "description": "cross mark"
+  , "category": "Symbols"
+  , "aliases": [
+      "x"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "❎"
+  , "description": "cross mark button"
+  , "category": "Symbols"
+  , "aliases": [
+      "negative_squared_cross_mark"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "➰"
+  , "description": "curly loop"
+  , "category": "Symbols"
+  , "aliases": [
+      "curly_loop"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "➿"
+  , "description": "double curly loop"
+  , "category": "Symbols"
+  , "aliases": [
+      "loop"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "〽️"
+  , "description": "part alternation mark"
+  , "category": "Symbols"
+  , "aliases": [
+      "part_alternation_mark"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "3.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "✳️"
+  , "description": "eight-spoked asterisk"
+  , "category": "Symbols"
+  , "aliases": [
+      "eight_spoked_asterisk"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "✴️"
+  , "description": "eight-pointed star"
+  , "category": "Symbols"
+  , "aliases": [
+      "eight_pointed_black_star"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "❇️"
+  , "description": "sparkle"
+  , "category": "Symbols"
+  , "aliases": [
+      "sparkle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "©️"
+  , "description": "copyright"
+  , "category": "Symbols"
+  , "aliases": [
+      "copyright"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "®️"
+  , "description": "registered"
+  , "category": "Symbols"
+  , "aliases": [
+      "registered"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "™️"
+  , "description": "trade mark"
+  , "category": "Symbols"
+  , "aliases": [
+      "tm"
+    ]
+  , "tags": [
+      "trademark"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "#️⃣"
+  , "description": "keycap: #"
+  , "category": "Symbols"
+  , "aliases": [
+      "hash"
+    ]
+  , "tags": [
+      "number"
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "*️⃣"
+  , "description": "keycap: *"
+  , "category": "Symbols"
+  , "aliases": [
+      "asterisk"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "0️⃣"
+  , "description": "keycap: 0"
+  , "category": "Symbols"
+  , "aliases": [
+      "zero"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "1️⃣"
+  , "description": "keycap: 1"
+  , "category": "Symbols"
+  , "aliases": [
+      "one"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "2️⃣"
+  , "description": "keycap: 2"
+  , "category": "Symbols"
+  , "aliases": [
+      "two"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "3️⃣"
+  , "description": "keycap: 3"
+  , "category": "Symbols"
+  , "aliases": [
+      "three"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "4️⃣"
+  , "description": "keycap: 4"
+  , "category": "Symbols"
+  , "aliases": [
+      "four"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "5️⃣"
+  , "description": "keycap: 5"
+  , "category": "Symbols"
+  , "aliases": [
+      "five"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "6️⃣"
+  , "description": "keycap: 6"
+  , "category": "Symbols"
+  , "aliases": [
+      "six"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "7️⃣"
+  , "description": "keycap: 7"
+  , "category": "Symbols"
+  , "aliases": [
+      "seven"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "8️⃣"
+  , "description": "keycap: 8"
+  , "category": "Symbols"
+  , "aliases": [
+      "eight"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "9️⃣"
+  , "description": "keycap: 9"
+  , "category": "Symbols"
+  , "aliases": [
+      "nine"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔟"
+  , "description": "keycap: 10"
+  , "category": "Symbols"
+  , "aliases": [
+      "keycap_ten"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔠"
+  , "description": "input latin uppercase"
+  , "category": "Symbols"
+  , "aliases": [
+      "capital_abcd"
+    ]
+  , "tags": [
+      "letters"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔡"
+  , "description": "input latin lowercase"
+  , "category": "Symbols"
+  , "aliases": [
+      "abcd"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔢"
+  , "description": "input numbers"
+  , "category": "Symbols"
+  , "aliases": [
+      "1234"
+    ]
+  , "tags": [
+      "numbers"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔣"
+  , "description": "input symbols"
+  , "category": "Symbols"
+  , "aliases": [
+      "symbols"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔤"
+  , "description": "input latin letters"
+  , "category": "Symbols"
+  , "aliases": [
+      "abc"
+    ]
+  , "tags": [
+      "alphabet"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🅰️"
+  , "description": "A button (blood type)"
+  , "category": "Symbols"
+  , "aliases": [
+      "a"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆎"
+  , "description": "AB button (blood type)"
+  , "category": "Symbols"
+  , "aliases": [
+      "ab"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🅱️"
+  , "description": "B button (blood type)"
+  , "category": "Symbols"
+  , "aliases": [
+      "b"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆑"
+  , "description": "CL button"
+  , "category": "Symbols"
+  , "aliases": [
+      "cl"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆒"
+  , "description": "COOL button"
+  , "category": "Symbols"
+  , "aliases": [
+      "cool"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆓"
+  , "description": "FREE button"
+  , "category": "Symbols"
+  , "aliases": [
+      "free"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "ℹ️"
+  , "description": "information"
+  , "category": "Symbols"
+  , "aliases": [
+      "information_source"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "3.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆔"
+  , "description": "ID button"
+  , "category": "Symbols"
+  , "aliases": [
+      "id"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "Ⓜ️"
+  , "description": "circled M"
+  , "category": "Symbols"
+  , "aliases": [
+      "m"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆕"
+  , "description": "NEW button"
+  , "category": "Symbols"
+  , "aliases": [
+      "new"
+    ]
+  , "tags": [
+      "fresh"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆖"
+  , "description": "NG button"
+  , "category": "Symbols"
+  , "aliases": [
+      "ng"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🅾️"
+  , "description": "O button (blood type)"
+  , "category": "Symbols"
+  , "aliases": [
+      "o2"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆗"
+  , "description": "OK button"
+  , "category": "Symbols"
+  , "aliases": [
+      "ok"
+    ]
+  , "tags": [
+      "yes"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🅿️"
+  , "description": "P button"
+  , "category": "Symbols"
+  , "aliases": [
+      "parking"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆘"
+  , "description": "SOS button"
+  , "category": "Symbols"
+  , "aliases": [
+      "sos"
+    ]
+  , "tags": [
+      "help"
+    , "emergency"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆙"
+  , "description": "UP! button"
+  , "category": "Symbols"
+  , "aliases": [
+      "up"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🆚"
+  , "description": "VS button"
+  , "category": "Symbols"
+  , "aliases": [
+      "vs"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈁"
+  , "description": "Japanese “here” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "koko"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈂️"
+  , "description": "Japanese “service charge” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "sa"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈷️"
+  , "description": "Japanese “monthly amount” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u6708"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈶"
+  , "description": "Japanese “not free of charge” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u6709"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈯"
+  , "description": "Japanese “reserved” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u6307"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🉐"
+  , "description": "Japanese “bargain” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "ideograph_advantage"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈹"
+  , "description": "Japanese “discount” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u5272"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈚"
+  , "description": "Japanese “free of charge” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u7121"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈲"
+  , "description": "Japanese “prohibited” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u7981"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🉑"
+  , "description": "Japanese “acceptable” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "accept"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈸"
+  , "description": "Japanese “application” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u7533"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈴"
+  , "description": "Japanese “passing grade” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u5408"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈳"
+  , "description": "Japanese “vacancy” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u7a7a"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "㊗️"
+  , "description": "Japanese “congratulations” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "congratulations"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "㊙️"
+  , "description": "Japanese “secret” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "secret"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈺"
+  , "description": "Japanese “open for business” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u55b6"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🈵"
+  , "description": "Japanese “no vacancy” button"
+  , "category": "Symbols"
+  , "aliases": [
+      "u6e80"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔴"
+  , "description": "red circle"
+  , "category": "Symbols"
+  , "aliases": [
+      "red_circle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🟠"
+  , "description": "orange circle"
+  , "category": "Symbols"
+  , "aliases": [
+      "orange_circle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🟡"
+  , "description": "yellow circle"
+  , "category": "Symbols"
+  , "aliases": [
+      "yellow_circle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🟢"
+  , "description": "green circle"
+  , "category": "Symbols"
+  , "aliases": [
+      "green_circle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🔵"
+  , "description": "blue circle"
+  , "category": "Symbols"
+  , "aliases": [
+      "large_blue_circle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🟣"
+  , "description": "purple circle"
+  , "category": "Symbols"
+  , "aliases": [
+      "purple_circle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🟤"
+  , "description": "brown circle"
+  , "category": "Symbols"
+  , "aliases": [
+      "brown_circle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "⚫"
+  , "description": "black circle"
+  , "category": "Symbols"
+  , "aliases": [
+      "black_circle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⚪"
+  , "description": "white circle"
+  , "category": "Symbols"
+  , "aliases": [
+      "white_circle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "4.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🟥"
+  , "description": "red square"
+  , "category": "Symbols"
+  , "aliases": [
+      "red_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🟧"
+  , "description": "orange square"
+  , "category": "Symbols"
+  , "aliases": [
+      "orange_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🟨"
+  , "description": "yellow square"
+  , "category": "Symbols"
+  , "aliases": [
+      "yellow_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🟩"
+  , "description": "green square"
+  , "category": "Symbols"
+  , "aliases": [
+      "green_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🟦"
+  , "description": "blue square"
+  , "category": "Symbols"
+  , "aliases": [
+      "blue_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🟪"
+  , "description": "purple square"
+  , "category": "Symbols"
+  , "aliases": [
+      "purple_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "🟫"
+  , "description": "brown square"
+  , "category": "Symbols"
+  , "aliases": [
+      "brown_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
+  }
+, {
+    "emoji": "⬛"
+  , "description": "black large square"
+  , "category": "Symbols"
+  , "aliases": [
+      "black_large_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "⬜"
+  , "description": "white large square"
+  , "category": "Symbols"
+  , "aliases": [
+      "white_large_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "5.1"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "◼️"
+  , "description": "black medium square"
+  , "category": "Symbols"
+  , "aliases": [
+      "black_medium_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "3.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "◻️"
+  , "description": "white medium square"
+  , "category": "Symbols"
+  , "aliases": [
+      "white_medium_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "3.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "◾"
+  , "description": "black medium-small square"
+  , "category": "Symbols"
+  , "aliases": [
+      "black_medium_small_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "3.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "◽"
+  , "description": "white medium-small square"
+  , "category": "Symbols"
+  , "aliases": [
+      "white_medium_small_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "3.2"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "▪️"
+  , "description": "black small square"
+  , "category": "Symbols"
+  , "aliases": [
+      "black_small_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "▫️"
+  , "description": "white small square"
+  , "category": "Symbols"
+  , "aliases": [
+      "white_small_square"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": ""
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔶"
+  , "description": "large orange diamond"
+  , "category": "Symbols"
+  , "aliases": [
+      "large_orange_diamond"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔷"
+  , "description": "large blue diamond"
+  , "category": "Symbols"
+  , "aliases": [
+      "large_blue_diamond"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔸"
+  , "description": "small orange diamond"
+  , "category": "Symbols"
+  , "aliases": [
+      "small_orange_diamond"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔹"
+  , "description": "small blue diamond"
+  , "category": "Symbols"
+  , "aliases": [
+      "small_blue_diamond"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔺"
+  , "description": "red triangle pointed up"
+  , "category": "Symbols"
+  , "aliases": [
+      "small_red_triangle"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔻"
+  , "description": "red triangle pointed down"
+  , "category": "Symbols"
+  , "aliases": [
+      "small_red_triangle_down"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "💠"
+  , "description": "diamond with a dot"
+  , "category": "Symbols"
+  , "aliases": [
+      "diamond_shape_with_a_dot_inside"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔘"
+  , "description": "radio button"
+  , "category": "Symbols"
+  , "aliases": [
+      "radio_button"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔳"
+  , "description": "white square button"
+  , "category": "Symbols"
+  , "aliases": [
+      "white_square_button"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🔲"
+  , "description": "black square button"
+  , "category": "Symbols"
+  , "aliases": [
+      "black_square_button"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏁"
+  , "description": "chequered flag"
+  , "category": "Flags"
+  , "aliases": [
+      "checkered_flag"
+    ]
+  , "tags": [
+      "milestone"
+    , "finish"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🚩"
+  , "description": "triangular flag"
+  , "category": "Flags"
+  , "aliases": [
+      "triangular_flag_on_post"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🎌"
+  , "description": "crossed flags"
+  , "category": "Flags"
+  , "aliases": [
+      "crossed_flags"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🏴"
+  , "description": "black flag"
+  , "category": "Flags"
+  , "aliases": [
+      "black_flag"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏳️"
+  , "description": "white flag"
+  , "category": "Flags"
+  , "aliases": [
+      "white_flag"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "7.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🏳️‍🌈"
+  , "description": "rainbow flag"
+  , "category": "Flags"
+  , "aliases": [
+      "rainbow_flag"
+    ]
+  , "tags": [
+      "pride"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "10.0"
+  }
+, {
+    "emoji": "🏳️‍⚧️"
+  , "description": "transgender flag"
+  , "category": "Flags"
+  , "aliases": [
+      "transgender_flag"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🏴‍☠️"
+  , "description": "pirate flag"
+  , "category": "Flags"
+  , "aliases": [
+      "pirate_flag"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇦🇨"
+  , "description": "flag: Ascension Island"
+  , "category": "Flags"
+  , "aliases": [
+      "ascension_island"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇦🇩"
+  , "description": "flag: Andorra"
+  , "category": "Flags"
+  , "aliases": [
+      "andorra"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇪"
+  , "description": "flag: United Arab Emirates"
+  , "category": "Flags"
+  , "aliases": [
+      "united_arab_emirates"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇫"
+  , "description": "flag: Afghanistan"
+  , "category": "Flags"
+  , "aliases": [
+      "afghanistan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇬"
+  , "description": "flag: Antigua & Barbuda"
+  , "category": "Flags"
+  , "aliases": [
+      "antigua_barbuda"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇮"
+  , "description": "flag: Anguilla"
+  , "category": "Flags"
+  , "aliases": [
+      "anguilla"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇱"
+  , "description": "flag: Albania"
+  , "category": "Flags"
+  , "aliases": [
+      "albania"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇲"
+  , "description": "flag: Armenia"
+  , "category": "Flags"
+  , "aliases": [
+      "armenia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇴"
+  , "description": "flag: Angola"
+  , "category": "Flags"
+  , "aliases": [
+      "angola"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇶"
+  , "description": "flag: Antarctica"
+  , "category": "Flags"
+  , "aliases": [
+      "antarctica"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇦🇷"
+  , "description": "flag: Argentina"
+  , "category": "Flags"
+  , "aliases": [
+      "argentina"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇸"
+  , "description": "flag: American Samoa"
+  , "category": "Flags"
+  , "aliases": [
+      "american_samoa"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇹"
+  , "description": "flag: Austria"
+  , "category": "Flags"
+  , "aliases": [
+      "austria"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇺"
+  , "description": "flag: Australia"
+  , "category": "Flags"
+  , "aliases": [
+      "australia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇼"
+  , "description": "flag: Aruba"
+  , "category": "Flags"
+  , "aliases": [
+      "aruba"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇦🇽"
+  , "description": "flag: Åland Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "aland_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇦🇿"
+  , "description": "flag: Azerbaijan"
+  , "category": "Flags"
+  , "aliases": [
+      "azerbaijan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇦"
+  , "description": "flag: Bosnia & Herzegovina"
+  , "category": "Flags"
+  , "aliases": [
+      "bosnia_herzegovina"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇧"
+  , "description": "flag: Barbados"
+  , "category": "Flags"
+  , "aliases": [
+      "barbados"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇩"
+  , "description": "flag: Bangladesh"
+  , "category": "Flags"
+  , "aliases": [
+      "bangladesh"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇪"
+  , "description": "flag: Belgium"
+  , "category": "Flags"
+  , "aliases": [
+      "belgium"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇫"
+  , "description": "flag: Burkina Faso"
+  , "category": "Flags"
+  , "aliases": [
+      "burkina_faso"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇬"
+  , "description": "flag: Bulgaria"
+  , "category": "Flags"
+  , "aliases": [
+      "bulgaria"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇭"
+  , "description": "flag: Bahrain"
+  , "category": "Flags"
+  , "aliases": [
+      "bahrain"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇮"
+  , "description": "flag: Burundi"
+  , "category": "Flags"
+  , "aliases": [
+      "burundi"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇯"
+  , "description": "flag: Benin"
+  , "category": "Flags"
+  , "aliases": [
+      "benin"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇱"
+  , "description": "flag: St. Barthélemy"
+  , "category": "Flags"
+  , "aliases": [
+      "st_barthelemy"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇧🇲"
+  , "description": "flag: Bermuda"
+  , "category": "Flags"
+  , "aliases": [
+      "bermuda"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇳"
+  , "description": "flag: Brunei"
+  , "category": "Flags"
+  , "aliases": [
+      "brunei"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇴"
+  , "description": "flag: Bolivia"
+  , "category": "Flags"
+  , "aliases": [
+      "bolivia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇶"
+  , "description": "flag: Caribbean Netherlands"
+  , "category": "Flags"
+  , "aliases": [
+      "caribbean_netherlands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇧🇷"
+  , "description": "flag: Brazil"
+  , "category": "Flags"
+  , "aliases": [
+      "brazil"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇸"
+  , "description": "flag: Bahamas"
+  , "category": "Flags"
+  , "aliases": [
+      "bahamas"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇹"
+  , "description": "flag: Bhutan"
+  , "category": "Flags"
+  , "aliases": [
+      "bhutan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇻"
+  , "description": "flag: Bouvet Island"
+  , "category": "Flags"
+  , "aliases": [
+      "bouvet_island"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇧🇼"
+  , "description": "flag: Botswana"
+  , "category": "Flags"
+  , "aliases": [
+      "botswana"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇾"
+  , "description": "flag: Belarus"
+  , "category": "Flags"
+  , "aliases": [
+      "belarus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇧🇿"
+  , "description": "flag: Belize"
+  , "category": "Flags"
+  , "aliases": [
+      "belize"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇦"
+  , "description": "flag: Canada"
+  , "category": "Flags"
+  , "aliases": [
+      "canada"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇨"
+  , "description": "flag: Cocos (Keeling) Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "cocos_islands"
+    ]
+  , "tags": [
+      "keeling"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇨🇩"
+  , "description": "flag: Congo - Kinshasa"
+  , "category": "Flags"
+  , "aliases": [
+      "congo_kinshasa"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇫"
+  , "description": "flag: Central African Republic"
+  , "category": "Flags"
+  , "aliases": [
+      "central_african_republic"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇬"
+  , "description": "flag: Congo - Brazzaville"
+  , "category": "Flags"
+  , "aliases": [
+      "congo_brazzaville"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇭"
+  , "description": "flag: Switzerland"
+  , "category": "Flags"
+  , "aliases": [
+      "switzerland"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇮"
+  , "description": "flag: Côte d’Ivoire"
+  , "category": "Flags"
+  , "aliases": [
+      "cote_divoire"
+    ]
+  , "tags": [
+      "ivory"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇰"
+  , "description": "flag: Cook Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "cook_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇱"
+  , "description": "flag: Chile"
+  , "category": "Flags"
+  , "aliases": [
+      "chile"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇲"
+  , "description": "flag: Cameroon"
+  , "category": "Flags"
+  , "aliases": [
+      "cameroon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇳"
+  , "description": "flag: China"
+  , "category": "Flags"
+  , "aliases": [
+      "cn"
+    ]
+  , "tags": [
+      "china"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🇨🇴"
+  , "description": "flag: Colombia"
+  , "category": "Flags"
+  , "aliases": [
+      "colombia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇵"
+  , "description": "flag: Clipperton Island"
+  , "category": "Flags"
+  , "aliases": [
+      "clipperton_island"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇨🇷"
+  , "description": "flag: Costa Rica"
+  , "category": "Flags"
+  , "aliases": [
+      "costa_rica"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇺"
+  , "description": "flag: Cuba"
+  , "category": "Flags"
+  , "aliases": [
+      "cuba"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇻"
+  , "description": "flag: Cape Verde"
+  , "category": "Flags"
+  , "aliases": [
+      "cape_verde"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇼"
+  , "description": "flag: Curaçao"
+  , "category": "Flags"
+  , "aliases": [
+      "curacao"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇽"
+  , "description": "flag: Christmas Island"
+  , "category": "Flags"
+  , "aliases": [
+      "christmas_island"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇨🇾"
+  , "description": "flag: Cyprus"
+  , "category": "Flags"
+  , "aliases": [
+      "cyprus"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇨🇿"
+  , "description": "flag: Czechia"
+  , "category": "Flags"
+  , "aliases": [
+      "czech_republic"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇩🇪"
+  , "description": "flag: Germany"
+  , "category": "Flags"
+  , "aliases": [
+      "de"
+    ]
+  , "tags": [
+      "flag"
+    , "germany"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🇩🇬"
+  , "description": "flag: Diego Garcia"
+  , "category": "Flags"
+  , "aliases": [
+      "diego_garcia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇩🇯"
+  , "description": "flag: Djibouti"
+  , "category": "Flags"
+  , "aliases": [
+      "djibouti"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇩🇰"
+  , "description": "flag: Denmark"
+  , "category": "Flags"
+  , "aliases": [
+      "denmark"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇩🇲"
+  , "description": "flag: Dominica"
+  , "category": "Flags"
+  , "aliases": [
+      "dominica"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇩🇴"
+  , "description": "flag: Dominican Republic"
+  , "category": "Flags"
+  , "aliases": [
+      "dominican_republic"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇩🇿"
+  , "description": "flag: Algeria"
+  , "category": "Flags"
+  , "aliases": [
+      "algeria"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇪🇦"
+  , "description": "flag: Ceuta & Melilla"
+  , "category": "Flags"
+  , "aliases": [
+      "ceuta_melilla"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇪🇨"
+  , "description": "flag: Ecuador"
+  , "category": "Flags"
+  , "aliases": [
+      "ecuador"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇪🇪"
+  , "description": "flag: Estonia"
+  , "category": "Flags"
+  , "aliases": [
+      "estonia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇪🇬"
+  , "description": "flag: Egypt"
+  , "category": "Flags"
+  , "aliases": [
+      "egypt"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇪🇭"
+  , "description": "flag: Western Sahara"
+  , "category": "Flags"
+  , "aliases": [
+      "western_sahara"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇪🇷"
+  , "description": "flag: Eritrea"
+  , "category": "Flags"
+  , "aliases": [
+      "eritrea"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇪🇸"
+  , "description": "flag: Spain"
+  , "category": "Flags"
+  , "aliases": [
+      "es"
+    ]
+  , "tags": [
+      "spain"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🇪🇹"
+  , "description": "flag: Ethiopia"
+  , "category": "Flags"
+  , "aliases": [
+      "ethiopia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇪🇺"
+  , "description": "flag: European Union"
+  , "category": "Flags"
+  , "aliases": [
+      "eu"
+    , "european_union"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇫🇮"
+  , "description": "flag: Finland"
+  , "category": "Flags"
+  , "aliases": [
+      "finland"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇫🇯"
+  , "description": "flag: Fiji"
+  , "category": "Flags"
+  , "aliases": [
+      "fiji"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇫🇰"
+  , "description": "flag: Falkland Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "falkland_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇫🇲"
+  , "description": "flag: Micronesia"
+  , "category": "Flags"
+  , "aliases": [
+      "micronesia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇫🇴"
+  , "description": "flag: Faroe Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "faroe_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇫🇷"
+  , "description": "flag: France"
+  , "category": "Flags"
+  , "aliases": [
+      "fr"
+    ]
+  , "tags": [
+      "france"
+    , "french"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🇬🇦"
+  , "description": "flag: Gabon"
+  , "category": "Flags"
+  , "aliases": [
+      "gabon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇧"
+  , "description": "flag: United Kingdom"
+  , "category": "Flags"
+  , "aliases": [
+      "gb"
+    , "uk"
+    ]
+  , "tags": [
+      "flag"
+    , "british"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🇬🇩"
+  , "description": "flag: Grenada"
+  , "category": "Flags"
+  , "aliases": [
+      "grenada"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇪"
+  , "description": "flag: Georgia"
+  , "category": "Flags"
+  , "aliases": [
+      "georgia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇫"
+  , "description": "flag: French Guiana"
+  , "category": "Flags"
+  , "aliases": [
+      "french_guiana"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇬"
+  , "description": "flag: Guernsey"
+  , "category": "Flags"
+  , "aliases": [
+      "guernsey"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇬🇭"
+  , "description": "flag: Ghana"
+  , "category": "Flags"
+  , "aliases": [
+      "ghana"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇮"
+  , "description": "flag: Gibraltar"
+  , "category": "Flags"
+  , "aliases": [
+      "gibraltar"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇱"
+  , "description": "flag: Greenland"
+  , "category": "Flags"
+  , "aliases": [
+      "greenland"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇬🇲"
+  , "description": "flag: Gambia"
+  , "category": "Flags"
+  , "aliases": [
+      "gambia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇳"
+  , "description": "flag: Guinea"
+  , "category": "Flags"
+  , "aliases": [
+      "guinea"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇵"
+  , "description": "flag: Guadeloupe"
+  , "category": "Flags"
+  , "aliases": [
+      "guadeloupe"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇬🇶"
+  , "description": "flag: Equatorial Guinea"
+  , "category": "Flags"
+  , "aliases": [
+      "equatorial_guinea"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇷"
+  , "description": "flag: Greece"
+  , "category": "Flags"
+  , "aliases": [
+      "greece"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇸"
+  , "description": "flag: South Georgia & South Sandwich Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "south_georgia_south_sandwich_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇬🇹"
+  , "description": "flag: Guatemala"
+  , "category": "Flags"
+  , "aliases": [
+      "guatemala"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇺"
+  , "description": "flag: Guam"
+  , "category": "Flags"
+  , "aliases": [
+      "guam"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇼"
+  , "description": "flag: Guinea-Bissau"
+  , "category": "Flags"
+  , "aliases": [
+      "guinea_bissau"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇬🇾"
+  , "description": "flag: Guyana"
+  , "category": "Flags"
+  , "aliases": [
+      "guyana"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇭🇰"
+  , "description": "flag: Hong Kong SAR China"
+  , "category": "Flags"
+  , "aliases": [
+      "hong_kong"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇭🇲"
+  , "description": "flag: Heard & McDonald Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "heard_mcdonald_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇭🇳"
+  , "description": "flag: Honduras"
+  , "category": "Flags"
+  , "aliases": [
+      "honduras"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇭🇷"
+  , "description": "flag: Croatia"
+  , "category": "Flags"
+  , "aliases": [
+      "croatia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇭🇹"
+  , "description": "flag: Haiti"
+  , "category": "Flags"
+  , "aliases": [
+      "haiti"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇭🇺"
+  , "description": "flag: Hungary"
+  , "category": "Flags"
+  , "aliases": [
+      "hungary"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇮🇨"
+  , "description": "flag: Canary Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "canary_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇮🇩"
+  , "description": "flag: Indonesia"
+  , "category": "Flags"
+  , "aliases": [
+      "indonesia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇮🇪"
+  , "description": "flag: Ireland"
+  , "category": "Flags"
+  , "aliases": [
+      "ireland"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇮🇱"
+  , "description": "flag: Israel"
+  , "category": "Flags"
+  , "aliases": [
+      "israel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇮🇲"
+  , "description": "flag: Isle of Man"
+  , "category": "Flags"
+  , "aliases": [
+      "isle_of_man"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇮🇳"
+  , "description": "flag: India"
+  , "category": "Flags"
+  , "aliases": [
+      "india"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇮🇴"
+  , "description": "flag: British Indian Ocean Territory"
+  , "category": "Flags"
+  , "aliases": [
+      "british_indian_ocean_territory"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇮🇶"
+  , "description": "flag: Iraq"
+  , "category": "Flags"
+  , "aliases": [
+      "iraq"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇮🇷"
+  , "description": "flag: Iran"
+  , "category": "Flags"
+  , "aliases": [
+      "iran"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇮🇸"
+  , "description": "flag: Iceland"
+  , "category": "Flags"
+  , "aliases": [
+      "iceland"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇮🇹"
+  , "description": "flag: Italy"
+  , "category": "Flags"
+  , "aliases": [
+      "it"
+    ]
+  , "tags": [
+      "italy"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🇯🇪"
+  , "description": "flag: Jersey"
+  , "category": "Flags"
+  , "aliases": [
+      "jersey"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇯🇲"
+  , "description": "flag: Jamaica"
+  , "category": "Flags"
+  , "aliases": [
+      "jamaica"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇯🇴"
+  , "description": "flag: Jordan"
+  , "category": "Flags"
+  , "aliases": [
+      "jordan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇯🇵"
+  , "description": "flag: Japan"
+  , "category": "Flags"
+  , "aliases": [
+      "jp"
+    ]
+  , "tags": [
+      "japan"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🇰🇪"
+  , "description": "flag: Kenya"
+  , "category": "Flags"
+  , "aliases": [
+      "kenya"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇰🇬"
+  , "description": "flag: Kyrgyzstan"
+  , "category": "Flags"
+  , "aliases": [
+      "kyrgyzstan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇰🇭"
+  , "description": "flag: Cambodia"
+  , "category": "Flags"
+  , "aliases": [
+      "cambodia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇰🇮"
+  , "description": "flag: Kiribati"
+  , "category": "Flags"
+  , "aliases": [
+      "kiribati"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇰🇲"
+  , "description": "flag: Comoros"
+  , "category": "Flags"
+  , "aliases": [
+      "comoros"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇰🇳"
+  , "description": "flag: St. Kitts & Nevis"
+  , "category": "Flags"
+  , "aliases": [
+      "st_kitts_nevis"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇰🇵"
+  , "description": "flag: North Korea"
+  , "category": "Flags"
+  , "aliases": [
+      "north_korea"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇰🇷"
+  , "description": "flag: South Korea"
+  , "category": "Flags"
+  , "aliases": [
+      "kr"
+    ]
+  , "tags": [
+      "korea"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🇰🇼"
+  , "description": "flag: Kuwait"
+  , "category": "Flags"
+  , "aliases": [
+      "kuwait"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇰🇾"
+  , "description": "flag: Cayman Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "cayman_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇰🇿"
+  , "description": "flag: Kazakhstan"
+  , "category": "Flags"
+  , "aliases": [
+      "kazakhstan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇦"
+  , "description": "flag: Laos"
+  , "category": "Flags"
+  , "aliases": [
+      "laos"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇧"
+  , "description": "flag: Lebanon"
+  , "category": "Flags"
+  , "aliases": [
+      "lebanon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇨"
+  , "description": "flag: St. Lucia"
+  , "category": "Flags"
+  , "aliases": [
+      "st_lucia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇮"
+  , "description": "flag: Liechtenstein"
+  , "category": "Flags"
+  , "aliases": [
+      "liechtenstein"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇰"
+  , "description": "flag: Sri Lanka"
+  , "category": "Flags"
+  , "aliases": [
+      "sri_lanka"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇷"
+  , "description": "flag: Liberia"
+  , "category": "Flags"
+  , "aliases": [
+      "liberia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇸"
+  , "description": "flag: Lesotho"
+  , "category": "Flags"
+  , "aliases": [
+      "lesotho"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇹"
+  , "description": "flag: Lithuania"
+  , "category": "Flags"
+  , "aliases": [
+      "lithuania"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇺"
+  , "description": "flag: Luxembourg"
+  , "category": "Flags"
+  , "aliases": [
+      "luxembourg"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇻"
+  , "description": "flag: Latvia"
+  , "category": "Flags"
+  , "aliases": [
+      "latvia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇱🇾"
+  , "description": "flag: Libya"
+  , "category": "Flags"
+  , "aliases": [
+      "libya"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇦"
+  , "description": "flag: Morocco"
+  , "category": "Flags"
+  , "aliases": [
+      "morocco"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇨"
+  , "description": "flag: Monaco"
+  , "category": "Flags"
+  , "aliases": [
+      "monaco"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇲🇩"
+  , "description": "flag: Moldova"
+  , "category": "Flags"
+  , "aliases": [
+      "moldova"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇪"
+  , "description": "flag: Montenegro"
+  , "category": "Flags"
+  , "aliases": [
+      "montenegro"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇫"
+  , "description": "flag: St. Martin"
+  , "category": "Flags"
+  , "aliases": [
+      "st_martin"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇲🇬"
+  , "description": "flag: Madagascar"
+  , "category": "Flags"
+  , "aliases": [
+      "madagascar"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇭"
+  , "description": "flag: Marshall Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "marshall_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇲🇰"
+  , "description": "flag: North Macedonia"
+  , "category": "Flags"
+  , "aliases": [
+      "macedonia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇱"
+  , "description": "flag: Mali"
+  , "category": "Flags"
+  , "aliases": [
+      "mali"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇲"
+  , "description": "flag: Myanmar (Burma)"
+  , "category": "Flags"
+  , "aliases": [
+      "myanmar"
+    ]
+  , "tags": [
+      "burma"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇳"
+  , "description": "flag: Mongolia"
+  , "category": "Flags"
+  , "aliases": [
+      "mongolia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇴"
+  , "description": "flag: Macao SAR China"
+  , "category": "Flags"
+  , "aliases": [
+      "macau"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇵"
+  , "description": "flag: Northern Mariana Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "northern_mariana_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇶"
+  , "description": "flag: Martinique"
+  , "category": "Flags"
+  , "aliases": [
+      "martinique"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇲🇷"
+  , "description": "flag: Mauritania"
+  , "category": "Flags"
+  , "aliases": [
+      "mauritania"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇸"
+  , "description": "flag: Montserrat"
+  , "category": "Flags"
+  , "aliases": [
+      "montserrat"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇹"
+  , "description": "flag: Malta"
+  , "category": "Flags"
+  , "aliases": [
+      "malta"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇺"
+  , "description": "flag: Mauritius"
+  , "category": "Flags"
+  , "aliases": [
+      "mauritius"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇲🇻"
+  , "description": "flag: Maldives"
+  , "category": "Flags"
+  , "aliases": [
+      "maldives"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇼"
+  , "description": "flag: Malawi"
+  , "category": "Flags"
+  , "aliases": [
+      "malawi"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇽"
+  , "description": "flag: Mexico"
+  , "category": "Flags"
+  , "aliases": [
+      "mexico"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇾"
+  , "description": "flag: Malaysia"
+  , "category": "Flags"
+  , "aliases": [
+      "malaysia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇲🇿"
+  , "description": "flag: Mozambique"
+  , "category": "Flags"
+  , "aliases": [
+      "mozambique"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇳🇦"
+  , "description": "flag: Namibia"
+  , "category": "Flags"
+  , "aliases": [
+      "namibia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇳🇨"
+  , "description": "flag: New Caledonia"
+  , "category": "Flags"
+  , "aliases": [
+      "new_caledonia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇳🇪"
+  , "description": "flag: Niger"
+  , "category": "Flags"
+  , "aliases": [
+      "niger"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇳🇫"
+  , "description": "flag: Norfolk Island"
+  , "category": "Flags"
+  , "aliases": [
+      "norfolk_island"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇳🇬"
+  , "description": "flag: Nigeria"
+  , "category": "Flags"
+  , "aliases": [
+      "nigeria"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇳🇮"
+  , "description": "flag: Nicaragua"
+  , "category": "Flags"
+  , "aliases": [
+      "nicaragua"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇳🇱"
+  , "description": "flag: Netherlands"
+  , "category": "Flags"
+  , "aliases": [
+      "netherlands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇳🇴"
+  , "description": "flag: Norway"
+  , "category": "Flags"
+  , "aliases": [
+      "norway"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇳🇵"
+  , "description": "flag: Nepal"
+  , "category": "Flags"
+  , "aliases": [
+      "nepal"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇳🇷"
+  , "description": "flag: Nauru"
+  , "category": "Flags"
+  , "aliases": [
+      "nauru"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇳🇺"
+  , "description": "flag: Niue"
+  , "category": "Flags"
+  , "aliases": [
+      "niue"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇳🇿"
+  , "description": "flag: New Zealand"
+  , "category": "Flags"
+  , "aliases": [
+      "new_zealand"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇴🇲"
+  , "description": "flag: Oman"
+  , "category": "Flags"
+  , "aliases": [
+      "oman"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇦"
+  , "description": "flag: Panama"
+  , "category": "Flags"
+  , "aliases": [
+      "panama"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇪"
+  , "description": "flag: Peru"
+  , "category": "Flags"
+  , "aliases": [
+      "peru"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇫"
+  , "description": "flag: French Polynesia"
+  , "category": "Flags"
+  , "aliases": [
+      "french_polynesia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇵🇬"
+  , "description": "flag: Papua New Guinea"
+  , "category": "Flags"
+  , "aliases": [
+      "papua_new_guinea"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇭"
+  , "description": "flag: Philippines"
+  , "category": "Flags"
+  , "aliases": [
+      "philippines"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇰"
+  , "description": "flag: Pakistan"
+  , "category": "Flags"
+  , "aliases": [
+      "pakistan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇱"
+  , "description": "flag: Poland"
+  , "category": "Flags"
+  , "aliases": [
+      "poland"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇲"
+  , "description": "flag: St. Pierre & Miquelon"
+  , "category": "Flags"
+  , "aliases": [
+      "st_pierre_miquelon"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇵🇳"
+  , "description": "flag: Pitcairn Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "pitcairn_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇵🇷"
+  , "description": "flag: Puerto Rico"
+  , "category": "Flags"
+  , "aliases": [
+      "puerto_rico"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇸"
+  , "description": "flag: Palestinian Territories"
+  , "category": "Flags"
+  , "aliases": [
+      "palestinian_territories"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇹"
+  , "description": "flag: Portugal"
+  , "category": "Flags"
+  , "aliases": [
+      "portugal"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇼"
+  , "description": "flag: Palau"
+  , "category": "Flags"
+  , "aliases": [
+      "palau"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇵🇾"
+  , "description": "flag: Paraguay"
+  , "category": "Flags"
+  , "aliases": [
+      "paraguay"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇶🇦"
+  , "description": "flag: Qatar"
+  , "category": "Flags"
+  , "aliases": [
+      "qatar"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇷🇪"
+  , "description": "flag: Réunion"
+  , "category": "Flags"
+  , "aliases": [
+      "reunion"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇷🇴"
+  , "description": "flag: Romania"
+  , "category": "Flags"
+  , "aliases": [
+      "romania"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇷🇸"
+  , "description": "flag: Serbia"
+  , "category": "Flags"
+  , "aliases": [
+      "serbia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇷🇺"
+  , "description": "flag: Russia"
+  , "category": "Flags"
+  , "aliases": [
+      "ru"
+    ]
+  , "tags": [
+      "russia"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🇷🇼"
+  , "description": "flag: Rwanda"
+  , "category": "Flags"
+  , "aliases": [
+      "rwanda"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇦"
+  , "description": "flag: Saudi Arabia"
+  , "category": "Flags"
+  , "aliases": [
+      "saudi_arabia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇧"
+  , "description": "flag: Solomon Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "solomon_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇨"
+  , "description": "flag: Seychelles"
+  , "category": "Flags"
+  , "aliases": [
+      "seychelles"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇩"
+  , "description": "flag: Sudan"
+  , "category": "Flags"
+  , "aliases": [
+      "sudan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇪"
+  , "description": "flag: Sweden"
+  , "category": "Flags"
+  , "aliases": [
+      "sweden"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇬"
+  , "description": "flag: Singapore"
+  , "category": "Flags"
+  , "aliases": [
+      "singapore"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇭"
+  , "description": "flag: St. Helena"
+  , "category": "Flags"
+  , "aliases": [
+      "st_helena"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇸🇮"
+  , "description": "flag: Slovenia"
+  , "category": "Flags"
+  , "aliases": [
+      "slovenia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇯"
+  , "description": "flag: Svalbard & Jan Mayen"
+  , "category": "Flags"
+  , "aliases": [
+      "svalbard_jan_mayen"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇸🇰"
+  , "description": "flag: Slovakia"
+  , "category": "Flags"
+  , "aliases": [
+      "slovakia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇱"
+  , "description": "flag: Sierra Leone"
+  , "category": "Flags"
+  , "aliases": [
+      "sierra_leone"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇲"
+  , "description": "flag: San Marino"
+  , "category": "Flags"
+  , "aliases": [
+      "san_marino"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇳"
+  , "description": "flag: Senegal"
+  , "category": "Flags"
+  , "aliases": [
+      "senegal"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇴"
+  , "description": "flag: Somalia"
+  , "category": "Flags"
+  , "aliases": [
+      "somalia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇷"
+  , "description": "flag: Suriname"
+  , "category": "Flags"
+  , "aliases": [
+      "suriname"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇸"
+  , "description": "flag: South Sudan"
+  , "category": "Flags"
+  , "aliases": [
+      "south_sudan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇹"
+  , "description": "flag: São Tomé & Príncipe"
+  , "category": "Flags"
+  , "aliases": [
+      "sao_tome_principe"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇻"
+  , "description": "flag: El Salvador"
+  , "category": "Flags"
+  , "aliases": [
+      "el_salvador"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇽"
+  , "description": "flag: Sint Maarten"
+  , "category": "Flags"
+  , "aliases": [
+      "sint_maarten"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇾"
+  , "description": "flag: Syria"
+  , "category": "Flags"
+  , "aliases": [
+      "syria"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇸🇿"
+  , "description": "flag: Eswatini"
+  , "category": "Flags"
+  , "aliases": [
+      "swaziland"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇦"
+  , "description": "flag: Tristan da Cunha"
+  , "category": "Flags"
+  , "aliases": [
+      "tristan_da_cunha"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇹🇨"
+  , "description": "flag: Turks & Caicos Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "turks_caicos_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇩"
+  , "description": "flag: Chad"
+  , "category": "Flags"
+  , "aliases": [
+      "chad"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇹🇫"
+  , "description": "flag: French Southern Territories"
+  , "category": "Flags"
+  , "aliases": [
+      "french_southern_territories"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇬"
+  , "description": "flag: Togo"
+  , "category": "Flags"
+  , "aliases": [
+      "togo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇭"
+  , "description": "flag: Thailand"
+  , "category": "Flags"
+  , "aliases": [
+      "thailand"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇯"
+  , "description": "flag: Tajikistan"
+  , "category": "Flags"
+  , "aliases": [
+      "tajikistan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇰"
+  , "description": "flag: Tokelau"
+  , "category": "Flags"
+  , "aliases": [
+      "tokelau"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇹🇱"
+  , "description": "flag: Timor-Leste"
+  , "category": "Flags"
+  , "aliases": [
+      "timor_leste"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇲"
+  , "description": "flag: Turkmenistan"
+  , "category": "Flags"
+  , "aliases": [
+      "turkmenistan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇳"
+  , "description": "flag: Tunisia"
+  , "category": "Flags"
+  , "aliases": [
+      "tunisia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇴"
+  , "description": "flag: Tonga"
+  , "category": "Flags"
+  , "aliases": [
+      "tonga"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇷"
+  , "description": "flag: Turkey"
+  , "category": "Flags"
+  , "aliases": [
+      "tr"
+    ]
+  , "tags": [
+      "turkey"
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🇹🇹"
+  , "description": "flag: Trinidad & Tobago"
+  , "category": "Flags"
+  , "aliases": [
+      "trinidad_tobago"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇻"
+  , "description": "flag: Tuvalu"
+  , "category": "Flags"
+  , "aliases": [
+      "tuvalu"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇹🇼"
+  , "description": "flag: Taiwan"
+  , "category": "Flags"
+  , "aliases": [
+      "taiwan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇹🇿"
+  , "description": "flag: Tanzania"
+  , "category": "Flags"
+  , "aliases": [
+      "tanzania"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇺🇦"
+  , "description": "flag: Ukraine"
+  , "category": "Flags"
+  , "aliases": [
+      "ukraine"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇺🇬"
+  , "description": "flag: Uganda"
+  , "category": "Flags"
+  , "aliases": [
+      "uganda"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇺🇲"
+  , "description": "flag: U.S. Outlying Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "us_outlying_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇺🇳"
+  , "description": "flag: United Nations"
+  , "category": "Flags"
+  , "aliases": [
+      "united_nations"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇺🇸"
+  , "description": "flag: United States"
+  , "category": "Flags"
+  , "aliases": [
+      "us"
+    ]
+  , "tags": [
+      "flag"
+    , "united"
+    , "america"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🇺🇾"
+  , "description": "flag: Uruguay"
+  , "category": "Flags"
+  , "aliases": [
+      "uruguay"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇺🇿"
+  , "description": "flag: Uzbekistan"
+  , "category": "Flags"
+  , "aliases": [
+      "uzbekistan"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇻🇦"
+  , "description": "flag: Vatican City"
+  , "category": "Flags"
+  , "aliases": [
+      "vatican_city"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇻🇨"
+  , "description": "flag: St. Vincent & Grenadines"
+  , "category": "Flags"
+  , "aliases": [
+      "st_vincent_grenadines"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇻🇪"
+  , "description": "flag: Venezuela"
+  , "category": "Flags"
+  , "aliases": [
+      "venezuela"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇻🇬"
+  , "description": "flag: British Virgin Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "british_virgin_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇻🇮"
+  , "description": "flag: U.S. Virgin Islands"
+  , "category": "Flags"
+  , "aliases": [
+      "us_virgin_islands"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇻🇳"
+  , "description": "flag: Vietnam"
+  , "category": "Flags"
+  , "aliases": [
+      "vietnam"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇻🇺"
+  , "description": "flag: Vanuatu"
+  , "category": "Flags"
+  , "aliases": [
+      "vanuatu"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇼🇫"
+  , "description": "flag: Wallis & Futuna"
+  , "category": "Flags"
+  , "aliases": [
+      "wallis_futuna"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇼🇸"
+  , "description": "flag: Samoa"
+  , "category": "Flags"
+  , "aliases": [
+      "samoa"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇽🇰"
+  , "description": "flag: Kosovo"
+  , "category": "Flags"
+  , "aliases": [
+      "kosovo"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇾🇪"
+  , "description": "flag: Yemen"
+  , "category": "Flags"
+  , "aliases": [
+      "yemen"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇾🇹"
+  , "description": "flag: Mayotte"
+  , "category": "Flags"
+  , "aliases": [
+      "mayotte"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "9.0"
+  }
+, {
+    "emoji": "🇿🇦"
+  , "description": "flag: South Africa"
+  , "category": "Flags"
+  , "aliases": [
+      "south_africa"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇿🇲"
+  , "description": "flag: Zambia"
+  , "category": "Flags"
+  , "aliases": [
+      "zambia"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🇿🇼"
+  , "description": "flag: Zimbabwe"
+  , "category": "Flags"
+  , "aliases": [
+      "zimbabwe"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "8.3"
+  }
+, {
+    "emoji": "🏴󠁧󠁢󠁥󠁮󠁧󠁿"
+  , "description": "flag: England"
+  , "category": "Flags"
+  , "aliases": [
+      "england"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🏴󠁧󠁢󠁳󠁣󠁴󠁿"
+  , "description": "flag: Scotland"
+  , "category": "Flags"
+  , "aliases": [
+      "scotland"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🏴󠁧󠁢󠁷󠁬󠁳󠁿"
+  , "description": "flag: Wales"
+  , "category": "Flags"
+  , "aliases": [
+      "wales"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+]

--- a/src/clojurians_log/db/import.clj
+++ b/src/clojurians_log/db/import.clj
@@ -18,7 +18,7 @@
   {:pre [(string? ts) (string? channel)]}
   (str channel "--" ts))
 
-(defmulti event->tx :subtype)
+(defmulti event->tx (juxt :type :subtype))
 
 (defmethod event->tx :default [_]
   ;; return nil by default, this will let us skip events we don't (yet) care
@@ -44,20 +44,20 @@
                            :thread-inst (jt/to-java-date thread-inst)
                            :day         (time-util/format-inst-day thread-inst)}))))))
 
-(defmethod event->tx nil [message]
+(defmethod event->tx ["message" nil] [message]
   (message->tx message))
 
-(defmethod event->tx "message_deleted" [{:keys [deleted_ts channel] :as message}]
+(defmethod event->tx ["message" "message_deleted"] [{:keys [deleted_ts channel] :as message}]
   [(if d/cloud?
      :db/retractEntity
      :db.fn/retractEntity) [:message/key (message-key {:channel channel :ts deleted_ts})]])
 
-(defmethod event->tx "message_changed" [{:keys [message channel]}]
+(defmethod event->tx ["message" "message_changed"] [{:keys [message channel]}]
   (event->tx (assoc message :channel channel)))
 
 ;; Thread replies which are copied to the channel. For now we only include them
 ;; in the thread.
-(defmethod event->tx "thread_broadcast" [message]
+(defmethod event->tx ["message" "thread_broadcast"] [message]
   (message->tx message))
 
 (defn user->tx [{:keys [id name real_name is_admin is_owner profile]}]
@@ -93,6 +93,18 @@
 (defn emoji->tx [[shortcode url]]
   #:emoji {:shortcode (name shortcode)
            :url       url})
+
+(defmethod event->tx ["reaction_added" nil] [{:keys [user item reaction item_user event_ts ts]}]
+  ;; Placeholder just to show that we're getting some data.
+  ;; TODO: return Datomic transaction data to create a reaction entity
+  (println "+" reaction)
+  nil)
+
+(defmethod event->tx ["reaction_removed" nil] [{:keys [user item reaction item_user event_ts ts]}]
+  ;; Placeholder just to show that we're getting some data.
+  ;; TODO: return Datomic transaction data to retract a reaction entity
+  (println "-" reaction)
+  nil)
 
 (defn lines-reducible [^BufferedReader rdr]
   (reify clojure.lang.IReduceInit

--- a/src/clojurians_log/db/import.clj
+++ b/src/clojurians_log/db/import.clj
@@ -97,8 +97,11 @@
 (defmethod event->tx ["reaction_added" nil] [{:keys [user item reaction item_user event_ts ts]}]
   ;; Placeholder just to show that we're getting some data.
   ;; TODO: return Datomic transaction data to create a reaction entity
-  (println "+" reaction)
-  nil)
+  {:reaction/type "reaction_added"
+   :reaction/emoji [:emoji/shortcode reaction]
+   :reaction/ts ts
+   :reaction/user [:user/slack-id user]
+   :reaction/message [:message/key (message-key item)]})
 
 (defmethod event->tx ["reaction_removed" nil] [{:keys [user item reaction item_user event_ts ts]}]
   ;; Placeholder just to show that we're getting some data.

--- a/src/clojurians_log/db/import.clj
+++ b/src/clojurians_log/db/import.clj
@@ -95,13 +95,11 @@
            :url       url})
 
 (defmethod event->tx ["reaction_added" nil] [{:keys [user item reaction item_user event_ts ts]}]
-  ;; Placeholder just to show that we're getting some data.
-  ;; TODO: return Datomic transaction data to create a reaction entity
   {:reaction/type "reaction_added"
-   :reaction/emoji [:emoji/shortcode reaction]
+   :reaction/emoji {:emoji/shortcode reaction}
    :reaction/ts ts
    :reaction/user [:user/slack-id user]
-   :reaction/message [:message/key (message-key item)]})
+   :reaction/message {:message/key (message-key item)}})
 
 (defmethod event->tx ["reaction_removed" nil] [{:keys [user item reaction item_user event_ts ts]}]
   ;; Placeholder just to show that we're getting some data.

--- a/src/clojurians_log/db/queries.clj
+++ b/src/clojurians_log/db/queries.clj
@@ -50,7 +50,6 @@
 (def ^:private pull-message-pattern
   '(pull ?msg
          [:message/text
-          :message/key
           :message/ts
           :message/thread-ts
           {:reaction/_message [:reaction/type {:reaction/emoji [*]}]}

--- a/src/clojurians_log/db/queries.clj
+++ b/src/clojurians_log/db/queries.clj
@@ -52,7 +52,8 @@
          [:message/text
           :message/ts
           :message/thread-ts
-          {:reaction/_message [:reaction/type {:reaction/emoji [*]}]}
+          {:reaction/_message [:reaction/user 
+                               :reaction/type {:reaction/emoji [*]}]}
           {:message/user [:user/name
                           :user/slack-id
                           :user-profile/real-name

--- a/src/clojurians_log/db/queries.clj
+++ b/src/clojurians_log/db/queries.clj
@@ -50,8 +50,10 @@
 (def ^:private pull-message-pattern
   '(pull ?msg
          [:message/text
+          :message/key
           :message/ts
           :message/thread-ts
+          {:reaction/_message [:reaction/type {:reaction/emoji [*]}]}
           {:message/user [:user/name
                           :user/slack-id
                           :user-profile/real-name

--- a/src/clojurians_log/db/schema.clj
+++ b/src/clojurians_log/db/schema.clj
@@ -1,159 +1,153 @@
 (ns clojurians-log.db.schema)
 
 (def message-schema
-  [#:db{:ident       :message/key
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string
-        :unique      :db.unique/identity
-        :doc         "Key consisting of channel id + ts. Useful for upserts and refs."}
-   #:db{:ident       :message/text
-        :valueType   :db.type/string
-        :cardinality :db.cardinality/one
-        :doc         "Message text (markdown)"}
-   #:db{:ident       :message/channel
-        :valueType   :db.type/ref
-        :cardinality :db.cardinality/one
-        :doc         "Channel the message was posted in."
-        :index       true}
-   #:db{:ident       :message/user
-        :valueType   :db.type/ref
-        :cardinality :db.cardinality/one
-        :doc         "User who posted the message"}
-   #:db{:ident       :message/ts
-        :valueType   :db.type/string
-        :cardinality :db.cardinality/one
-        :doc         "Message timestamp (seconds since epoch up to 6 decimals). Stored as string because it is used by slack as a kind of identifier. Unique per channel."}
-   #_#:db{:ident       :message/inst
-          :valueType   :db.type/instant
-          :cardinality :db.cardinality/one
-          :doc         "Same as :message/ts, but parsed to java.util.Date. This is lossy: Date has milisecond precision, ts has microseconds."}
-   #:db{:ident       :message/thread-ts
-        :valueType   :db.type/string
-        :cardinality :db.cardinality/one
-        :doc         "Thread parent message timestamp (seconds since epoch up to 6 decimals). Stored as string because it is used by slack as a kind of identifier. Unique per channel."
-        :index       true}
-   #:db{:ident       :message/thread-inst
-        :valueType   :db.type/instant
-        :cardinality :db.cardinality/one
-        :doc         "Same as :message/thread-ts, but parsed to java.util.Date. This is lossy: Date has milisecond precision, ts has microseconds."}
-   #:db{:ident       :message/day
-        :valueType   :db.type/string
-        :cardinality :db.cardinality/one
-        :doc         "The day this message is categorized under, e.g. 2017-11-20."
-        :index       true}
-   #_#:db{:ident       :message/team
-          :valueType   :db.type/ref
-          :cardinality :db.cardinality/one}
-   #_#:db{:ident       :message/source-team
-          :valueType   :db.type/ref
-          :cardinality :db.cardinality/one}])
+  [{:db/ident       :message/key
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string
+    :db/unique      :db.unique/identity
+    :db/doc         "Key consisting of channel id + ts. Useful for upserts and refs."}
+   {:db/ident       :message/text
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc         "Message text (markdown)"}
+   {:db/ident       :message/channel
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/doc         "Channel the message was posted in."
+    :db/index       true}
+   {:db/ident       :message/user
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/doc         "User who posted the message"}
+   {:db/ident       :message/ts
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc         "Message timestamp (seconds since epoch up to 6 decimals). Stored as string because it is used by slack as a kind of identifier. Unique per channel."}
+   {:db/ident       :message/thread-ts
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc         "Thread parent message timestamp (seconds since epoch up to 6 decimals). Stored as string because it is used by slack as a kind of identifier. Unique per channel."
+    :db/index       true}
+   {:db/ident       :message/thread-inst
+    :db/valueType   :db.type/instant
+    :db/cardinality :db.cardinality/one
+    :db/doc         "Same as :message/thread-ts, but parsed to java.util.Date. This is lossy: Date has milisecond precision, ts has microseconds."}
+   {:db/ident       :message/day
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/doc         "The day this message is categorized under, e.g. 2017-11-20."
+    :db/index       true}])
 
 (def event-schema
-  [#:db{:ident       :event/subtype
-        :valueType   :db.type/string
-        :cardinality :db.cardinality/one}
-   #:db{:ident       :event/ts
-        :valueType   :db.type/string
-        :cardinality :db.cardinality/one}])
+  [{:db/ident       :event/subtype
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :event/ts
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}])
 
 (def user-schema
-  [#:db{:ident       :user/slack-id,
-        :valueType   :db.type/string,
-        :cardinality :db.cardinality/one,
-        :unique      :db.unique/identity,
-        :doc         "Internal user identifier used by slack. Alphanumeric, starts with U."}
-   #:db{:ident       :user/name,
-        :valueType   :db.type/string,
-        :cardinality :db.cardinality/one,
-        :unique      :db.unique/identity,
-        :doc         "A user's public handle."}
-   #:db{:ident       :user/real-name,
-        :valueType   :db.type/string,
-        :cardinality :db.cardinality/one}
-   #:db{:ident       :user/admin?,
-        :cardinality :db.cardinality/one,
-        :valueType   :db.type/boolean}
-   #:db{:ident       :user/owner?,
-        :cardinality :db.cardinality/one,
-        :valueType   :db.type/boolean}
-   #:db{:ident       :user/profile,
-        :valueType   :db.type/ref,
-        :cardinality :db.cardinality/one,
-        :doc         "Reference to a user's profile, which contains email, avatar, display name, etc."}])
+  [{:db/ident       :user/slack-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity
+    :db/doc         "Internal user identifier used by slack. Alphanumeric starts with U."}
+   {:db/ident       :user/name
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity
+    :db/doc         "A user's public handle."}
+   {:db/ident       :user/real-name
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :user/admin?
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/boolean}
+   {:db/ident       :user/owner?
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/boolean}
+   {:db/ident       :user/profile
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/doc         "Reference to a user's profile which contains email, avatar, display name, etc."}])
 
 (def user-profile-schema
-  [#:db{:ident       :user-profile/email
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/first-name
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/last-name
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/display-name
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/display-name-normalized
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/real-name
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/real-name-normalized
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/avatar-hash
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/title
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/image-original
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/image-24
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/image-32
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/image-48
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/image-72
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/image-192
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}
-   #:db{:ident       :user-profile/image-512
-        :cardinality :db.cardinality/one
-        :valueType   :db.type/string}])
+  [{:db/ident       :user-profile/email
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/first-name
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/last-name
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/display-name
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/display-name-normalized
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/real-name
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/real-name-normalized
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/avatar-hash
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/title
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/image-original
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/image-24
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/image-32
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/image-48
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/image-72
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/image-192
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}
+   {:db/ident       :user-profile/image-512
+    :db/cardinality :db.cardinality/one
+    :db/valueType   :db.type/string}])
 
 (def channel-schema
-  [#:db{:ident       :channel/slack-id
-        :valueType   :db.type/string
-        :cardinality :db.cardinality/one
-        :unique      :db.unique/identity}
-   #:db{:ident       :channel/name
-        :valueType   :db.type/string
-        :cardinality :db.cardinality/one
-        :unique      :db.unique/identity}
-   #:db{:ident       :channel/created
-        :valueType   :db.type/long
-        :cardinality :db.cardinality/one}
-   #:db{:ident       :channel/creator
-        :valueType   :db.type/ref
-        :cardinality :db.cardinality/one}])
+  [{:db/ident       :channel/slack-id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity}
+   {:db/ident       :channel/name
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity}
+   {:db/ident       :channel/created
+    :db/valueType   :db.type/long
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :channel/creator
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one}])
 
 (def emoji-schema
-  [#:db{:ident       :emoji/shortcode
-        :valueType   :db.type/string
-        :cardinality :db.cardinality/one}
-   #:db{:ident       :emoji/url
-        :valueType   :db.type/string
-        :cardinality :db.cardinality/one}])
+  [{:db/ident       :emoji/shortcode
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :emoji/url
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}])
+
+(def reaction-schema
+  [#_{:db/ident :reaction/reaction
+      ,,,}])
 
 (def full-schema
   (concat message-schema
@@ -161,4 +155,5 @@
           user-schema
           user-profile-schema
           channel-schema
-          emoji-schema))
+          emoji-schema
+          reaction-schema))

--- a/src/clojurians_log/db/schema.clj
+++ b/src/clojurians_log/db/schema.clj
@@ -140,14 +140,28 @@
 (def emoji-schema
   [{:db/ident       :emoji/shortcode
     :db/valueType   :db.type/string
-    :db/cardinality :db.cardinality/one}
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity}
    {:db/ident       :emoji/url
     :db/valueType   :db.type/string
     :db/cardinality :db.cardinality/one}])
 
 (def reaction-schema
-  [#_{:db/ident :reaction/reaction
-      ,,,}])
+  [{:db/ident       :reaction/type
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :reaction/emoji
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :reaction/ts
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :reaction/user
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :reaction/message
+    :db/valueType   :db.type/ref
+    :db/cardinality :db.cardinality/one}])
 
 (def full-schema
   (concat message-schema

--- a/src/clojurians_log/repl.clj
+++ b/src/clojurians_log/repl.clj
@@ -77,7 +77,7 @@
   or from EDN files (demo data)."
   [file]
   (println (str file))
-  (let [msgs (filter #(= (:type %) "message") (data/event-seq file))
+  (let [msgs (data/event-seq file)
         events (keep import/event->tx msgs)]
     (doseq [event events]
       @(d/transact-async (conn) [event]))))
@@ -180,6 +180,7 @@
   (do
     (user/reset)
     (load-demo-data! "/home/arne/github/clojurians-log-demo-data")
+    (load-demo-data! "/tmp/demo_data")
     )
   )
 

--- a/src/clojurians_log/slack_messages.clj
+++ b/src/clojurians_log/slack_messages.clj
@@ -53,7 +53,7 @@
   ([text]
    (text->emoji text {}))
   ([text emoji-map]
-   (let [emoji-map (merge emoji-map @standard-emoji-map)]
+   (let [emoji-map (merge @standard-emoji-map emoji-map)]
      (loop [shortcode text]
        (when-let [link (emoji-map shortcode)]
          (cond

--- a/src/clojurians_log/slack_messages.clj
+++ b/src/clojurians_log/slack_messages.clj
@@ -43,9 +43,11 @@
   `(text->emoji \"smile\") ;; => \"😄\"`"
   (delay
     (with-open [r (io/reader (io/resource "emojis.json"))]
-      (let [emoji-list (-> (json/read r :key-fn keyword)
-                           :emojis)]
-        (into {} (map (juxt :name :emoji) emoji-list))))))
+      (let [emoji-list (json/read r :key-fn keyword)]
+        (into {}
+              (map
+               (comp first #(for [alias (:aliases %)] [alias (:emoji %)]))
+               emoji-list))))))
 
 (defn text->emoji
   ([text]

--- a/src/clojurians_log/styles.clj
+++ b/src/clojurians_log/styles.clj
@@ -349,9 +349,27 @@
 
   [:.message.thread-msg {:margin-left "1rem"}]
 
+  [:.message-reaction-bar
+   {:margin-top "8px"
+    :margin-bottom "8px"}]
+  
+  [:.message-reaction 
+   {:font-size "11px"
+    :line-height "16px"
+    :padding "4px 6px"
+    :display "inline-flex"
+    :align-items "center"
+    :vertical-align "top"
+    :background "#f6f6f6"
+    :border "none"
+    :border-radius "12px"
+    :margin-bottom "4px"
+    :margin-right "4px"}]
+  
   [:.emoji
-   [:img {:height "22px"
-          :width  "22px"}]]
+   {:margin-right "4px"}
+   [:img {:height "16px"
+          :width  "16px"}]]
 
   [:.content
    {:display "flex"

--- a/src/clojurians_log/views.clj
+++ b/src/clojurians_log/views.clj
@@ -198,11 +198,12 @@
                                      (cl.tu/format-inst-time inst)]]
            [:span.message_star]
            [:span.message_content [:p (slack-messages/message->hiccup text usernames emojis)]]
-           "Reactions: "
-           (for [reaction (:reaction/_message message)]
-             [:span.emoji
-              (slack-messages/text->emoji
-               (get-in reaction [:reaction/emoji :emoji/shortcode]))])])))
+           (let [reaction-group (group-by #(get-in % [:reaction/emoji :emoji/shortcode]) (:reaction/_message message))]
+             (for [[emoji-shortcode reactions] reaction-group]
+               [:div.message-reaction
+                (slack-messages/text->emoji emoji-shortcode)
+                " "
+                (count reactions)]))])))
 
 (defn- message-hiccup
   "Returns either a single message hiccup, or if the given message starts a thread,

--- a/src/clojurians_log/views.clj
+++ b/src/clojurians_log/views.clj
@@ -198,12 +198,13 @@
                                      (cl.tu/format-inst-time inst)]]
            [:span.message_star]
            [:span.message_content [:p (slack-messages/message->hiccup text usernames emojis)]]
-           (let [reaction-group (group-by #(get-in % [:reaction/emoji :emoji/shortcode]) (:reaction/_message message))]
-             (for [[emoji-shortcode reactions] reaction-group]
-               [:div.message-reaction
-                (slack-messages/text->emoji emoji-shortcode)
-                " "
-                (count reactions)]))])))
+           [:div.message-reaction-bar
+            (let [reaction-group (group-by #(get-in % [:reaction/emoji :emoji/shortcode]) (:reaction/_message message))]
+              (for [[emoji-shortcode reactions] reaction-group]
+                [:div.message-reaction
+                 [:span.emoji (slack-messages/text->emoji emoji-shortcode emojis)]
+                 " "
+                 (count reactions)]))]])))
 
 (defn- message-hiccup
   "Returns either a single message hiccup, or if the given message starts a thread,

--- a/src/clojurians_log/views.clj
+++ b/src/clojurians_log/views.clj
@@ -197,7 +197,12 @@
                                                           :ts ts})}
                                      (cl.tu/format-inst-time inst)]]
            [:span.message_star]
-           [:span.message_content [:p (slack-messages/message->hiccup text usernames emojis)]]])))
+           [:span.message_content [:p (slack-messages/message->hiccup text usernames emojis)]]
+           "Reactions: "
+           (for [reaction (:reaction/_message message)]
+             [:span.emoji
+              (slack-messages/text->emoji
+               (get-in reaction [:reaction/emoji :emoji/shortcode]))])])))
 
 (defn- message-hiccup
   "Returns either a single message hiccup, or if the given message starts a thread,


### PR DESCRIPTION
<!--
This process uses the Collective Code Construction Contract
https://rfc.zeromq.org/spec:44/C4/

We merge quickly, but do keep a few things in mind

- make small PRs
- state the problem you are addressing (Problem: ... Solution: ...)
- add yourself to CONTRIBUTORS.md
- try not to break the build
-->

Implement emoji reactions :star_struck: 

![2020-11-05-170404_503x127_scrot](https://user-images.githubusercontent.com/32212/98570501-cf756600-22b3-11eb-8857-7ba2fe1a0747.png)

- [x] Adjust `event->tx` to handle non-message events
- [x] Add datomic schema so we can store reactions
- [ ] implement `"reaction_added"` / `"reaction_removed"` (see `event->tx` placeholders)
- [x] Adjust the `pull-message-pattern` so we also pull all reactions for a message (*1) 
- [x] Render reactions below a message (stretch goal: show usernames on hover)
- [x] Add CSS for the reaction buttons

Regarding the querying (*1), given what we have I think adding reactions to the pull pattern is the most straightforward thing to do here. The alternatives are: query for the reactions in a separate query, or convert the code to use `d/entity` and fetch them via attribute lookup on demand.

