### PR TITLE
Better deal with recursive markup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@dev:first
-  clojure: lambdaisland/clojure@dev:first
+  kaocha: lambdaisland/kaocha@0.0.1
+  clojure: lambdaisland/clojure@0.0.1
 
 commands:
   checkout_and_run:

--- a/src/clojurians_log/data.clj
+++ b/src/clojurians_log/data.clj
@@ -36,26 +36,6 @@
            line-seq
            (map json/read-json)))
 
-(defn channel-messages [channel-id date]
-  (some->> (event-seq (io/resource (str "logs/" date ".txt")))
-           (sequence
-            (comp
-             (filter #(and (= "message" (:type %))
-                           (nil? (:subtype %))
-                           (= channel-id (:channel %))))
-             (map coerce-message)))))
-;; TODO handle message_changed and message_deleted messages
-
-(defn load-channel-messages [{:keys [request] :as context}]
-  (let [{:keys [channel date]} (:params request)
-        {channel-id :id :as channel} (channel-by-name channel)
-        messages (channel-messages channel-id date)]
-    (assoc context
-           :data/channel channel
-           :data/messages messages
-           :data/date date)))
-
-
 (defn log-files []
   (file-seq (io/file (io/resource "logs"))))
 

--- a/src/clojurians_log/message_parser.clj
+++ b/src/clojurians_log/message_parser.clj
@@ -326,8 +326,12 @@
          doall))
 
   (with-redefs-fn {#'parse2-inner (fn [_] (throw (ex-info "error" {})))}
-    (fn [] (let [data (clojurians-log.db.queries/channel-day-messages (user/db) "clojure" "2018-02-02")]
-            (->> data
-                 (map #(parse2 (:message/text %)))
-                 doall))))
+    (fn []
+      (let [data (clojurians-log.db.queries/channel-day-messages (user/db)
+                                                                 "clojure"
+                                                                 "2018-02-02")]
+        (->> data
+             (map #(parse2 (:message/text %)))
+             doall))))
+
   )

--- a/src/clojurians_log/routes.clj
+++ b/src/clojurians_log/routes.clj
@@ -160,6 +160,3 @@
                          :get log-route}]
    ["/{channel}/{date}/{ts}" {:name :clojurians-log.routes/message,
                               :get log-route}]])
-
-(comment
-  (data/load-channel-messages {:request {:params {:channel "clojure" :year "2017" :month "01" :day "01"}}}))

--- a/test/clojurians_log/message_parser_test.clj
+++ b/test/clojurians_log/message_parser_test.clj
@@ -1,96 +1,96 @@
 (ns clojurians-log.message-parser-test
-  (:require [clojurians-log.message-parser :refer [parse2] :as sut]
+  (:require [clojurians-log.message-parser :as mp]
             [clojure.test :refer :all]))
 
 (deftest test-parse2
   (testing "basic messages"
     (is (= [[:undecorated "This is a normal message"]]
-           (parse2 "This is a normal message")))
+           (mp/parse2 "This is a normal message")))
     (is (= [[:user-id "U4F2A0Z8ER"]]
-           (parse2 "<@U4F2A0Z8ER>")))
+           (mp/parse2 "<@U4F2A0Z8ER>")))
     (is (= [[:channel-id "C4F2A26SGSHBW"]]
-           (parse2 "<#C4F2A26SGSHBW>")))
+           (mp/parse2 "<#C4F2A26SGSHBW>")))
     (is (= [[:channel-id "C03S1L9DN" "clojurescript"]]
-           (parse2 "<#C03S1L9DN|clojurescript>")))
+           (mp/parse2 "<#C03S1L9DN|clojurescript>")))
     (is (= [[:inline-code "DateTime"]]
-           (parse2 "`DateTime`")))
+           (mp/parse2 "`DateTime`")))
     (is (= [[:code-block "(some clojure code)"]]
-           (parse2 "```(some clojure code)```")))
+           (mp/parse2 "```(some clojure code)```")))
     (is (= [[:bold "hey!"]]
-           (parse2 "*hey!*")))
+           (mp/parse2 "*hey!*")))
     (is (= [[:italic "hello"]]
-           (parse2 "_hello_")))
+           (mp/parse2 "_hello_")))
     (is (= [[:emoji "thumbsup"]]
-           (parse2 ":thumbsup:")))
+           (mp/parse2 ":thumbsup:")))
     (is (= [[:emoji "+1"]]
-           (parse2 ":+1:")))
+           (mp/parse2 ":+1:")))
     (is (= [[:emoji "-1"]]
-           (parse2 ":-1:")))
+           (mp/parse2 ":-1:")))
     (is (= [[:emoji "e-mail"]]
-           (parse2 ":e-mail:")))
+           (mp/parse2 ":e-mail:")))
     (is (= [[:bold "hi!"] [:undecorated " "] [:emoji "smiles"]]
-           (parse2 "*hi!* :smiles:")))
+           (mp/parse2 "*hi!* :smiles:")))
     (is (= [[:undecorated "12:34:56:78:90:12:34:56:78:90:12:34:56:78:90:12"]]
-           (parse2 "12:34:56:78:90:12:34:56:78:90:12:34:56:78:90:12")))
+           (mp/parse2 "12:34:56:78:90:12:34:56:78:90:12:34:56:78:90:12")))
     (is (= [[:strike-through "strike-through"]]
-           (parse2 "~strike-through~")))
+           (mp/parse2 "~strike-through~")))
     (is (= [[:undecorated "just_some_snake_case"]]
-           (parse2 "just_some_snake_case")))
+           (mp/parse2 "just_some_snake_case")))
     (is (= [[:url "https://google.com"]]
-           (parse2 "<https://google.com>")))
+           (mp/parse2 "<https://google.com>")))
     (is (= [[:undecorated "from: "]
             [:url "https://google.com"]]
-           (parse2 "from: <https://google.com>")))
+           (mp/parse2 "from: <https://google.com>")))
     (is (= [[:undecorated "&<>"]]
-           (parse2 "&amp;&lt;&gt;"))))
+           (mp/parse2 "&amp;&lt;&gt;"))))
 
   (testing "nested regions"
     ;; Basic case
     (is (= [[:bold "hello"]]
-           (parse2 "*hello*")))
+           (mp/parse2 "*hello*")))
 
     ;; two unrelated regions
     (is (= [[:italic "hello"] [:undecorated " "] [:bold "world"]]
-           (parse2 "_hello_ *world*")))
+           (mp/parse2 "_hello_ *world*")))
 
     ;; single nested case
     (is (= [[:italic [:bold "hello"]]]
-           (parse2 "_*hello*_")))
+           (mp/parse2 "_*hello*_")))
 
     ;; undecorated text outside regions
     (is (= [[:bold "hello"] [:undecorated " world again"]]
-           (parse2 "*hello* world again")))
+           (mp/parse2 "*hello* world again")))
 
     (is (= [[:undecorated "hello "] [:bold "world"] [:undecorated " again"]]
-           (parse2 "hello *world* again")))
+           (mp/parse2 "hello *world* again")))
 
     (is (= [[:undecorated "hello world "] [:bold "again"]]
-           (parse2 "hello world *again*")))
+           (mp/parse2 "hello world *again*")))
 
     ;; undecorated text inside regions
     (is (= [[:italic [[:bold "hello"] [:undecorated " world"]]]]
-           (parse2 "_*hello* world_")))
+           (mp/parse2 "_*hello* world_")))
 
     (is (= [[:italic [[:undecorated "hello "] [:bold "world"]]]]
-           (parse2 "_hello *world*_")))
+           (mp/parse2 "_hello *world*_")))
 
     (is (= [[:italic [[:bold "hello"] [:undecorated " world again"]]]]
-           (parse2 "_*hello* world again_")))
+           (mp/parse2 "_*hello* world again_")))
 
     (is (= [[:italic [[:undecorated "hello "] [:bold "world"] [:undecorated " again"]]]]
-           (parse2 "_hello *world* again_")))
+           (mp/parse2 "_hello *world* again_")))
 
     (is (= [[:italic [[:undecorated "hello world "] [:bold "again"]]]]
-           (parse2 "_hello world *again*_")))
+           (mp/parse2 "_hello world *again*_")))
 
     ;; Two nested regions
     (is (= [[:italic [[:bold "hello"] [:undecorated " "] [:strike-through "world"]]]]
-           (parse2 "_*hello* ~world~_"))))
+           (mp/parse2 "_*hello* ~world~_"))))
 
   (testing "No nested regions inside a code block"
     (is (= [[:undecorated "Some text "]
             [:code-block "some code <#C03S1L9DN|clojurescript>"]]
-           (parse2 "Some text ```some code <#C03S1L9DN|clojurescript>```"))))
+           (mp/parse2 "Some text ```some code <#C03S1L9DN|clojurescript>```"))))
 
   (testing "putting it together"
     (let [message "Hey <@U4F2A0Z8ER>: here is the `my-ns.core` code ```
@@ -115,12 +115,12 @@ please respond in <#C346HE24SD>"]
               [:emoji "mindblown"]
               [:undecorated "\nplease respond in "]
               [:channel-id "C346HE24SD"]]
-             (parse2 message))))))
+             (mp/parse2 message))))))
 
 ;; Try out Slack message parsing at
 ;; https://api.slack.com/docs/messages/builder?msg=%7B%22text%22%3A%22xx1_%20*basic*%60%22%7D
 (deftest parse-test
-  (are [x y] (= y (parse2 x))
+  (are [x y] (= y (mp/parse2 x))
     "basic"              [[:undecorated "basic"]]
     "*bold*"             [[:bold "bold"]]
     "basic *bold* basic" [[:undecorated "basic "] [:bold "bold"] [:undecorated " basic"]]

--- a/test/clojurians_log/slack_messages_test.clj
+++ b/test/clojurians_log/slack_messages_test.clj
@@ -1,14 +1,15 @@
 (ns clojurians-log.slack-messages-test
-  (:require [clojurians-log.slack-messages :refer :all]
+  (:require [clojurians-log.slack-messages :as sm]
+            [clojurians-log.message-parser :as mp]
             [clojure.test :refer :all]))
 
 (deftest test-extract-user-ids
   (is (= #{"ABC345" "ABC123"}
-         (extract-user-ids
+         (sm/extract-user-ids
           [{:message/text "Hello <@ABC123>, how's <@ABC345|jonny> doing?"}]))))
 
 (deftest test-nested-styled-segment
-  (is (= (clojurians-log.slack-messages/segment->hiccup
+  (is (= (sm/segment->hiccup
           [:strike-through
            [[:undecorated "you can use "]
             [:bold "::stest/opts"]
@@ -26,9 +27,79 @@
     (is (= [:p [[:b "Hey"] " "
                 [:span.username "@" "xandrews"]
                 " how are things?"]]
-           (message->hiccup message user-lookup)))
+           (sm/message->hiccup message user-lookup)))
     (is (= [:p ["Thanks, I'm wonderful " [:span.emoji "😄"]]]
-           (message->hiccup reply user-lookup)))))
+           (sm/message->hiccup reply user-lookup))))
+
+  (testing "real-world regressions"
+    ;; The main thing here is that there are no :undecorated tags left after
+    ;; conversion to hiccup
+    (is (= '([:b
+              "Hey everyone, we’re so excited to be here for DevOps Enterprise Summit talking about"]
+             "\n"
+             [:span.emoji "arrow_right"]
+             " "
+             [:i
+              [:b
+               ("Be sure to visit our booth "
+                [:a
+                 {:href "https://doesvirtual.com/teamform"}
+                 "https://doesvirtual.com/teamform"])]]
+             " \n"
+             [:span.emoji "tv"]
+             " "
+             [:i
+              [:b
+               ("Or join us anytime on Zoom - "
+                [:a {:href "https://bit.ly/3iIdX1X"} "https://bit.ly/3iIdX1X"])]]
+             "\n"
+             [:span.emoji "mega"]
+             " "
+             [:i
+              [:b
+               ("Schedule a private demo - "
+                [:a {:href "https://teamform.co/demo"} "https://teamform.co/demo"])]]
+             "\n"
+             [:span.emoji "gift"]
+             " "
+             [:i
+              [:b
+               ("Register for giveaway (1x PS5 or XBox Series X, 1 x 50min chat with the authors of Team Topologies, 20x IT Rev Books) "
+                [:a
+                 {:href "https://www.teamform.co/does-giveaway"}
+                 "https://www.teamform.co/does-giveaway"])]]
+             "\n\n"
+             [:b "We’ve got a exciting week with a bunch of demos of TeamForm scheduled"]
+             "\n"
+             [:span.emoji "star"]
+             " 11-11:15am PDT: TeamForm Live Demo: Managing Supply & Demand at Scale - join @ "
+             [:a
+              {:href "https://us02web.zoom.us/j/81956904920"}
+              "https://us02web.zoom.us/j/81956904920"]
+             "\n"
+             [:span.emoji "star"]
+             " 12:45-1:00pm PDT: TeamForm Live Demo: Measuring Team Organising Principles - join @ "
+             [:a
+              {:href "https://us02web.zoom.us/j/81956904920"}
+              "https://us02web.zoom.us/j/81956904920"]
+             "\n"
+             [:span.emoji "bar_chart"]
+             " 3:45-4pm PDT: TeamForm Live Demo: Measuring Team Proficiency - join @ "
+             [:a
+              {:href "https://us02web.zoom.us/j/81956904920"}
+              "https://us02web.zoom.us/j/81956904920"]
+             "\n\nLater this week:\n"
+             [:span.emoji "arrow_right"]
+             " Register for our AMA with Authors of TeamTopologies "
+             [:a {:href "https://sched.co/ej42"} "https://sched.co/ej42"]
+             " with "
+             "ULTTZCP7S"
+             " & "
+             "UBE001UAX")
+           (sm/segments->hiccup
+            (mp/parse2 "*Hey everyone, we\u2019re so excited to be here for DevOps Enterprise Summit talking about*\n:arrow_right: _*Be sure to visit our booth <https://doesvirtual.com/teamform>*_ \n:tv: _*Or join us anytime on Zoom -\u00a0<https://bit.ly/3iIdX1X>*_\n:mega: _*Schedule a private demo - <https://teamform.co/demo>*_\n:gift: _*Register for giveaway (1x PS5 or XBox Series X, 1 x 50min chat with the authors of Team Topologies, 20x IT Rev Books) <https://www.teamform.co/does-giveaway>*_\n\n*We\u2019ve got a exciting week with a bunch of demos of TeamForm scheduled*\n:star: 11-11:15am PDT: TeamForm Live Demo: Managing Supply &amp; Demand at Scale - join @ <https://us02web.zoom.us/j/81956904920>\n:star: 12:45-1:00pm PDT: TeamForm Live Demo: Measuring Team Organising Principles - join @ <https://us02web.zoom.us/j/81956904920>\n:bar_chart: 3:45-4pm PDT: TeamForm Live Demo: Measuring Team Proficiency - join @ <https://us02web.zoom.us/j/81956904920>\n\nLater this week:\n:arrow_right: Register for our AMA with Authors of TeamTopologies <https://sched.co/ej42> with <@ULTTZCP7S> &amp; <@UBE001UAX>"))))
+    )
+  )
 
 (deftest test-render-custom-emoji
   (let [message-1 "Oh no, :facepalm:"
@@ -39,14 +110,14 @@
             ["Oh no, "
              [:span.emoji
               [:img {:alt "facepalm" :src "https://emoji/facepalm.png"}]]]]
-           (message->hiccup message-1 {} emoji-map)))
+           (sm/message->hiccup message-1 {} emoji-map)))
     (is (= [:p
             [[:span.emoji
               [:img {:alt "picard" :src "https://emoji/facepalm.png"}]]]]
-           (message->hiccup message-2 {} emoji-map)))))
+           (sm/message->hiccup message-2 {} emoji-map)))))
 
 (deftest test-render-test
   (let [message     "*Hey* <@U4F2A0Z8ER> how are things?"
         user-lookup {"U4F2A0Z8ER" "xandrews"}]
     (is (=  "*Hey* @xandrews how are things?"
-            (message->text message user-lookup)))))
+            (sm/message->text message user-lookup)))))


### PR DESCRIPTION


We had some cases where an `:undecorated` tag was making its way through to the
hiccup compiler, and causing havoc. This adjusts the code that converts parsed
messages to hiccup to deal with arbitrary nesting.

It also improves message to text rendering (used for the the description meta
tag) in a similar way, and implements ~strikethrough~.

Deal more gracefully with missing user names. This is especially useful should
we end up parsing something as a username when it actually isn't.

Add a regression test case, and get rid of some :refer :all usage in the tests.