### PR TITLE
Make the about text configurable

### DIFF
--- a/resources/clojurians-log/about.md
+++ b/resources/clojurians-log/about.md
@@ -1,19 +1,33 @@
-About
-======
+# About Clojurians Log
 
-One of the main on-line hangouts for Clojure people is the 
-[Clojurians Slack community](http://clojurians.net).
+Welcome to Clojurians Log, a public archive of the [Clojurians Slack community](http://clojurians.net), going back all the way to 2015.
 
-Unfortunately it suffers from its popularity. Slack will only retain the last 10,000 messages of history,  
-that is less than two weeks of logs. A lot of valuable information is in that chat history.  
-The Clojureverse team has decided to set up this service so that the logs aren’t lost in time.
+We store these messages for posterity, so that the vast amounts of knowledge
+that are shared there are not lost, but instead are accessible to all, including
+search engines.
 
-If some channel is not logging, it's probably because @logbot isn't receiving its messages.  
-Feel free to invite @logbot to a channel to start logging.
+This Clojurians log is an offshoot of [ClojureVerse](https://clojureverse.org),
+a Clojure forum run by and for the community. We strongly believe that a strong
+and healthy community should create and manage its own spaces. ClojureVerse
+embodies that philosophy.
 
-The source code is in
- [this](https://github.com/clojureverse/clojurians-log-app)
-github repo, you are welcome to contribute.
-        
-The hosting of Clojurians Slack Log is kindly donated by
-[Exoscale.](https://www.exoscale.com)
+But the reality is that many conversations are still happening inside Slack's
+walled garden. Slack serves the community well, but it's also where
+information goes to die. We try to give all those valuable conversations a new
+lease on life.
+
+If a channel is not showing up in the logs then make sure you invite `@logbot`
+to the channel. While you're at it, you can also invite `@zulip-mirror-bot`, a
+bot which mirrors Slack channels to [Clojurians Zulip](https://clojurians.zulipchat.com/).
+
+The code that powers this site can be found on Github. The main application is
+written in Clojure, and we warmly welcome contributions. Together we continue to
+make this a better place.
+
+- [clojurians-log-app](https://github.com/clojureverse/clojurians-log-app)
+- [rtmbot](https://github.com/clojureverse/rtmbot)
+- [slack-backfill](https://github.com/lambdaisland/slack-backfill)
+
+ClojureVerse and the Clojurians Log are proudly set up and maintained by [Gaiwan](http://gaiwan.co), the company behind [Lambda Island Education](https://lambdaisland.com) and [Lambda Island Open Source](https://github.com/lambdaisland/open-source).
+
+Hosting of the Clojurians Log is provided by [Exoscale](https://www.exoscale.com).

--- a/resources/clojurians-log/config.edn
+++ b/resources/clojurians-log/config.edn
@@ -15,4 +15,5 @@
  :message-page {:cache-time #profile {:default 86400
                                       :dev     0
                                       :test    0}}
- :application  {:title "Clojurians Slack Log"}}
+ :application  {:title "Clojurians Slack Log"
+                :about #resource "clojurians-log/about.md"}}

--- a/src/clojurians_log/application.clj
+++ b/src/clojurians_log/application.clj
@@ -33,7 +33,7 @@
                                      (fn [request]
                                        (handler (assoc request
                                                        :endpoint endpoint
-                                                       ::title (get-in cfg [:application :title])
+                                                       :config cfg
                                                        ::slack-instance (get-in cfg [:slack :instance])))))))
                    (component/using [:datomic :config]))
    :middleware (new-middleware {:middleware clojurians-log.config/middleware-stack})

--- a/src/clojurians_log/config.clj
+++ b/src/clojurians_log/config.clj
@@ -8,6 +8,10 @@
             [ring.middleware.logger :refer [wrap-with-logger]]
             [ring.middleware.session.memory :as mem]))
 
+(defmethod aero/reader 'resource
+  [_ tag value]
+  (io/resource value))
+
 (def session-store (mem/memory-store))
 
 (def site-defaults

--- a/src/clojurians_log/routes.clj
+++ b/src/clojurians_log/routes.clj
@@ -89,7 +89,7 @@
                      :data/usernames (into {} (queries/user-names db user-ids))
                      :data/emojis (emoji-url-map db)
                      :data/channel-days (queries/channel-days db channel)
-                     :data/title (str channel " " date " | " (get request :clojurians-log.application/title))
+                     :data/title (str channel " " date " | " (get-in request [:config :application :title]))
                      :data/date date
                      :data/http-origin (get-in config [:http :origin]))
               views/log-page
@@ -104,7 +104,7 @@
 (defn index-route [{:keys [endpoint] :as request}]
   (let [db (db-from-endpoint endpoint)]
     (-> (make-context request)
-        (assoc :data/title (get request :clojurians-log.application/title)
+        (assoc :data/title (get-in request [:config :application :title])
                :data/channels (queries/channel-list db))
         views/channel-list-page
         add-cache-control-header
@@ -114,7 +114,7 @@
   (let [db (db-from-endpoint endpoint)
         {:keys [channel]} (:path-params request)]
     (-> (make-context request)
-        (assoc :data/title (str (get request :clojurians-log.application/title "Clojurians Slack Log") "| " channel)
+        (assoc :data/title (str (get-in request [:config :application :title]) "| " channel)
                :data/channel-days (queries/channel-days db channel)
                :data/channel-name channel)
         views/channel-page
@@ -125,8 +125,7 @@
   (-> request
       make-context
       (assoc :data/about-hiccup
-             (-> "clojurians-log/about.md"
-                 io/resource
+             (-> (get-in request [:config :application :about])
                  slurp
                  (m/md->hiccup {:encode? true})
                  (m/component)))

--- a/src/clojurians_log/styles.clj
+++ b/src/clojurians_log/styles.clj
@@ -339,8 +339,6 @@
       :border "none",
       :color "inherit"}]]]
 
-  [:h1 {:text-decoration "underline"}]
-
   [:.day-arrows
    {:margin "1rem 0 0 1rem"}
 
@@ -409,4 +407,13 @@
   [:.padding-15px
    {:padding-left "15px"}]
 
+  [:#about
+   {:max-width "800px"}
+   [:h1 {:font-size "2rem"
+         :margin-top "1.66rem"
+         :margin-bottom "2.33rem"}]
+   [:p :ul {:margin-bottom "1em"
+            :line-height "1.33rem"}]
+   [:ul {:padding-left "1rem"}]
+   [:li {:list-style-type "disc"}]]
   )

--- a/src/clojurians_log/views.clj
+++ b/src/clojurians_log/views.clj
@@ -42,7 +42,7 @@
 
 (defn og-title [{:keys [request]
                  :data/keys [title channel date target-message messages usernames] :as context}]
-  (let [app-title (:clojurians-log.application/title request)]
+  (let [app-title (get-in request [:config :application :title])]
     (cond
       ;; Is the message part of a thread?
       (thread-child? target-message)
@@ -140,7 +140,7 @@
 
 (defn- log-page-sidebar [{:data/keys [channel date channel-days] :as context}]
   [:div.sidebar.listings
-   [:div.app-title [:a {:href "/"} (get-in context [:request :clojurians-log.application/title])]]
+   [:div.app-title [:a {:href "/"} (get-in context [:request :config :application :title])]]
    [:p.disclaimer "This page is not created by, affiliated with, or supported by Slack Technologies, Inc."]
    (channel-list context)
    [:div.listings_direct-messages]])
@@ -224,7 +224,7 @@
    [:body
     (fork-me-badge)
     [:div.main
-     [:div.app-title [:a {:href "/"} (get-in context [:request :clojurians-log.application/title])]]
+     [:div.app-title [:a {:href "/"} (get-in context [:request :config :application :title])]]
      [:h1 "Channel: #" channel-name]
      [:ul.channel-days
       (for [[day cnt] channel-days]
@@ -245,7 +245,7 @@
        [:td
         [:div.app-title
          [:a {:href "/"}
-          (get-in context [:request :clojurians-log.application/title])]]]
+          (get-in context [:request :config :application :title])]]]
        [:td.padding-15px
         [:a {:href (path-for context :clojurians-log.routes/about)}
          "About"]]
@@ -269,8 +269,9 @@
     [:div.main
      [:div.app-title
       [:a {:href "/"}
-       (get-in context [:request :clojurians-log.application/title])]]
-     (:data/about-hiccup context)]]])
+       (get-in context [:request :config :application :title])]]
+     [:section#about
+      (:data/about-hiccup context)]]]])
 
 (defn- sitemap-xml [{:data/keys [channel-day-tuples http-origin] :as context}]
   [:urlset {:xmlns "http://www.sitemaps.org/schemas/sitemap/0.9"}


### PR DESCRIPTION
This allows you to provide an alternative path to a markdown file, so that we
can have a different about text for different slack communities.

This also gives the actual about page an overhaul in both content and styling.

@oxalorg  could you merge this? You don't need to spend much time on it, I just like to not merge my own PRs.

<!--
This process uses the Collective Code Construction Contract
https://rfc.zeromq.org/spec:44/C4/

We merge quickly, but do keep a few things in mind

- make small PRs
- state the problem you are addressing (Problem: ... Solution: ...)
- add yourself to CONTRIBUTORS.md
- try not to break the build
-->
