### PR TITLE
feat: prefer showing display name / real name

### DIFF
--- a/src/clojurians_log/db/queries.clj
+++ b/src/clojurians_log/db/queries.clj
@@ -54,6 +54,8 @@
           :message/thread-ts
           {:message/user [:user/name
                           :user/slack-id
+                          :user-profile/real-name
+                          :user-profile/display-name
                           :user-profile/image-48]}]))
 
 (defn channel-day-messages [db chan-name day]

--- a/src/clojurians_log/views.clj
+++ b/src/clojurians_log/views.clj
@@ -182,7 +182,7 @@
            {:id (cl.tu/format-inst-id inst) :class (when (thread-child? message) "thread-msg")}
            [:a.message_profile-pic {:href (str slack-instance "/team/" slack-id) :style (str "background-image: url(" image-48 ");")}]
            [:a.message_username {:href (str slack-instance "/team/" slack-id)}
-            (first (filter #(not (clojure.string/blank? %)) [display-name real-name name]))]
+            (some #(when-not (str/blank? %) %) [display-name real-name name])]
            [:span.message_timestamp [:a {:rel  "nofollow"
                                          :href (path-for context
                                                          :clojurians-log.routes/message

--- a/src/clojurians_log/views.clj
+++ b/src/clojurians_log/views.clj
@@ -172,7 +172,7 @@
    {:message/keys [user inst user text thread-ts ts] :as message}]
 
   (let [{:user/keys         [name slack-id]
-         :user-profile/keys [image-48]} user
+         :user-profile/keys [display-name real-name image-48]} user
         slack-instance (:clojurians-log.application/slack-instance request)]
 
     ;; things in the profile
@@ -181,7 +181,8 @@
     (list [:div.message
            {:id (cl.tu/format-inst-id inst) :class (when (thread-child? message) "thread-msg")}
            [:a.message_profile-pic {:href (str slack-instance "/team/" slack-id) :style (str "background-image: url(" image-48 ");")}]
-           [:a.message_username {:href (str slack-instance "/team/" slack-id)} name]
+           [:a.message_username {:href (str slack-instance "/team/" slack-id)}
+            (first (filter #(not (clojure.string/blank? %)) [display-name real-name name]))]
            [:span.message_timestamp [:a {:rel  "nofollow"
                                          :href (path-for context
                                                          :clojurians-log.routes/message


### PR DESCRIPTION
Problem: We display people's "handle" (login name), instead of the display name they have configured.

Solution: Prefers showing display name if it is non blank.

Logic: Show the first non-blank value from `[display-name, real-name, slack username/handle]` (Higesht priority will be display-name).

fixes #104 